### PR TITLE
Implement backend API and connect frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+*.log
+.DS_Store
+latin-ecom-backend/dist
+latin-ecom-backend/.turbo

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Latin Ecom Platform
+
+Este repositorio contiene el frontend (Vite + React) y el backend (Express + TypeScript) necesarios para la demo de LatinEcom.
+
+## Requisitos previos
+
+- Node.js 18+
+- npm 9+
+
+## Instalación
+
+```bash
+# Instalar dependencias del frontend
+cd latin-ecom
+npm install
+
+# Instalar dependencias del backend
+cd ../latin-ecom-backend
+npm install
+```
+
+## Ejecución en desarrollo
+
+En una terminal inicia el backend:
+
+```bash
+cd latin-ecom-backend
+npm run dev
+```
+
+Por defecto se expone en `http://localhost:4000`.
+
+En otra terminal inicia el frontend:
+
+```bash
+cd latin-ecom
+cp .env.example .env # Ajusta VITE_API_URL si es necesario
+npm run dev
+```
+
+El frontend consumirá el backend para obtener los datos del panel.
+
+## Scripts adicionales
+
+```bash
+# Backend: compilar a JavaScript
+npm run build
+
+# Frontend: ejecutar linter
+npm run lint
+
+# Frontend: ejecutar pruebas (vitest)
+npm test
+```
+
+## Estructura
+
+- `latin-ecom/`: Aplicación React.
+- `latin-ecom-backend/`: API REST en Express.
+- `Analisis funcional Ecomdrop/`: Documentación de producto.

--- a/latin-ecom-backend/package-lock.json
+++ b/latin-ecom-backend/package-lock.json
@@ -1,0 +1,1553 @@
+{
+  "name": "latin-ecom-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "latin-ecom-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "cors": "2.8.5",
+        "date-fns": "3.6.0",
+        "express": "4.21.1",
+        "nanoid": "5.0.7",
+        "zod": "3.23.8"
+      },
+      "devDependencies": {
+        "@types/cors": "2.8.17",
+        "@types/express": "4.17.21",
+        "@types/node": "22.8.7",
+        "tsx": "4.19.2",
+        "typescript": "5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.7.tgz",
+      "integrity": "sha512-LidcG+2UeYIWcMuMUpBKOnryBWG/rnmOHQR5apjn8myTQcx3rinFRn7DcIFhMnS0PPFSC6OafdIKEad0lj6U0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.9.tgz",
+      "integrity": "sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.10",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
+      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/latin-ecom-backend/package.json
+++ b/latin-ecom-backend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "latin-ecom-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "build": "tsc --project tsconfig.json"
+  },
+  "dependencies": {
+    "cors": "2.8.5",
+    "date-fns": "3.6.0",
+    "express": "4.21.1",
+    "nanoid": "5.0.7",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "2.8.17",
+    "@types/express": "4.17.21",
+    "@types/node": "22.8.7",
+    "tsx": "4.19.2",
+    "typescript": "5.6.3"
+  }
+}

--- a/latin-ecom-backend/src/data.ts
+++ b/latin-ecom-backend/src/data.ts
@@ -1,0 +1,319 @@
+import { addDays, subDays } from 'date-fns';
+import {
+  BillingBreakdownItem,
+  Connection,
+  DashboardPayload,
+  Movement,
+  Order,
+  OrderStatus,
+  OrderStatusSummaryItem,
+  Product,
+  TopProductSummary,
+  WalletRequest
+} from './types.js';
+
+const today = new Date();
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const initialProducts: Product[] = [
+  {
+    id: 'PRD-101',
+    name: 'Faja Reductora Post Parto',
+    category: 'Salud y Belleza',
+    provider: 'FitLine Bogotá',
+    cost: 18,
+    suggestedPrice: 39.99,
+    stock: 230,
+    shippingTime: '24h',
+    updatedAt: subDays(today, 1).toISOString(),
+    rating: 4.7
+  },
+  {
+    id: 'PRD-205',
+    name: 'Set de brochas profesionales 12p',
+    category: 'Belleza',
+    provider: 'GlamSupply Lima',
+    cost: 9.5,
+    suggestedPrice: 24.99,
+    stock: 560,
+    shippingTime: '48h',
+    updatedAt: subDays(today, 2).toISOString(),
+    rating: 4.8
+  },
+  {
+    id: 'PRD-314',
+    name: 'Zapatillas Urbanas StreetFlow',
+    category: 'Calzado',
+    provider: 'StreetKicks Santiago',
+    cost: 22,
+    suggestedPrice: 49.99,
+    stock: 140,
+    shippingTime: '72h',
+    updatedAt: subDays(today, 4).toISOString(),
+    rating: 4.5
+  },
+  {
+    id: 'PRD-407',
+    name: 'Licuadora Portátil SmoothGo',
+    category: 'Electrodomésticos',
+    provider: 'HomeTech Medellín',
+    cost: 16,
+    suggestedPrice: 34.99,
+    stock: 320,
+    shippingTime: '48h',
+    updatedAt: subDays(today, 1).toISOString(),
+    rating: 4.6
+  }
+];
+
+const initialOrders: Order[] = [
+  {
+    id: 'ORD-9001',
+    store: 'SofiFit Store',
+    product: 'Faja Reductora Post Parto',
+    customer: 'Laura Reyes',
+    createdAt: subDays(today, 1).toISOString(),
+    status: 'Pendiente',
+    paymentMethod: 'TC',
+    cost: 18,
+    shippingCost: 5.5,
+    salePrice: 39.99
+  },
+  {
+    id: 'ORD-9002',
+    store: 'GlowUp Boutique',
+    product: 'Set de brochas profesionales 12p',
+    customer: 'Camila Vargas',
+    createdAt: subDays(today, 3).toISOString(),
+    status: 'Confirmado',
+    paymentMethod: 'TC',
+    cost: 9.5,
+    shippingCost: 4,
+    salePrice: 24.99,
+    trackingCode: 'CHL123456789'
+  },
+  {
+    id: 'ORD-9003',
+    store: 'UrbanStep',
+    product: 'Zapatillas Urbanas StreetFlow',
+    customer: 'Jorge Pérez',
+    createdAt: subDays(today, 5).toISOString(),
+    status: 'Despachado',
+    paymentMethod: 'COD',
+    cost: 22,
+    shippingCost: 6.5,
+    salePrice: 49.99,
+    trackingCode: 'PER987654321'
+  },
+  {
+    id: 'ORD-9004',
+    store: 'DetoxLife',
+    product: 'Licuadora Portátil SmoothGo',
+    customer: 'Mariana Torres',
+    createdAt: subDays(today, 6).toISOString(),
+    status: 'Entregado',
+    paymentMethod: 'COD',
+    cost: 16,
+    shippingCost: 5,
+    salePrice: 34.99,
+    trackingCode: 'COL456123789'
+  },
+  {
+    id: 'ORD-9005',
+    store: 'SofiFit Store',
+    product: 'Faja Reductora Post Parto',
+    customer: 'Dayana Castro',
+    createdAt: subDays(today, 2).toISOString(),
+    status: 'Registrar pago',
+    paymentMethod: 'TC',
+    cost: 18,
+    shippingCost: 5.5,
+    salePrice: 39.99
+  }
+];
+
+const initialMovements: Movement[] = [
+  {
+    id: 'MOV-1001',
+    type: 'Ingreso',
+    category: 'Recarga',
+    description: 'Recarga USDT - Binance',
+    amount: 1500,
+    date: subDays(today, 2).toISOString()
+  },
+  {
+    id: 'MOV-1002',
+    type: 'Egreso',
+    category: 'Confirmación pedido',
+    description: 'ORD-9002 - Confirmación costo + envío',
+    amount: -13.5,
+    date: subDays(today, 2).toISOString()
+  },
+  {
+    id: 'MOV-1003',
+    type: 'Ingreso',
+    category: 'Acreditación',
+    description: 'ORD-9004 - Pedido COD entregado',
+    amount: 27.49,
+    date: subDays(today, 1).toISOString()
+  },
+  {
+    id: 'MOV-1004',
+    type: 'Egreso',
+    category: 'Envío',
+    description: 'Pago courier semana 32',
+    amount: -78.9,
+    date: subDays(today, 4).toISOString()
+  },
+  {
+    id: 'MOV-1005',
+    type: 'Egreso',
+    category: 'Comisión',
+    description: 'Comisión plataforma - Agosto',
+    amount: -125.35,
+    date: subDays(today, 7).toISOString()
+  }
+];
+
+const initialWalletRequests: WalletRequest[] = [
+  {
+    id: 'REQ-501',
+    type: 'Ingreso',
+    status: 'Pendiente',
+    amount: 1200,
+    createdAt: subDays(today, 1).toISOString(),
+    reference: 'TRX-9932ABCD'
+  },
+  {
+    id: 'REQ-502',
+    type: 'Retiro',
+    status: 'Aprobada',
+    amount: 650,
+    createdAt: subDays(today, 4).toISOString(),
+    processedAt: subDays(today, 3).toISOString(),
+    reference: 'RET-5567XYZ'
+  },
+  {
+    id: 'REQ-503',
+    type: 'Ingreso',
+    status: 'Rechazada',
+    amount: 300,
+    createdAt: subDays(today, 6).toISOString(),
+    processedAt: subDays(today, 5).toISOString(),
+    reference: 'TRX-1099LMN'
+  }
+];
+
+const initialConnections: Connection[] = [
+  {
+    id: 'CON-101',
+    storeName: 'SofiFit Store',
+    platform: 'Shopify',
+    status: 'Activa',
+    connectedAt: subDays(today, 90).toISOString(),
+    lastSync: addDays(subDays(today, 0), -0.2).toISOString()
+  },
+  {
+    id: 'CON-102',
+    storeName: 'GlowUp Boutique',
+    platform: 'Shopify',
+    status: 'Sincronizando',
+    connectedAt: subDays(today, 45).toISOString(),
+    lastSync: subDays(today, 1).toISOString()
+  },
+  {
+    id: 'CON-103',
+    storeName: 'UrbanStep',
+    platform: 'Shopify',
+    status: 'Error',
+    connectedAt: subDays(today, 30).toISOString(),
+    lastSync: subDays(today, 3).toISOString()
+  }
+];
+
+export let products: Product[] = clone(initialProducts);
+export let orders: Order[] = clone(initialOrders);
+export let movements: Movement[] = clone(initialMovements);
+export let walletRequests: WalletRequest[] = clone(initialWalletRequests);
+export let connections: Connection[] = clone(initialConnections);
+
+export const resetDataStores = () => {
+  products = clone(initialProducts);
+  orders = clone(initialOrders);
+  movements = clone(initialMovements);
+  walletRequests = clone(initialWalletRequests);
+  connections = clone(initialConnections);
+};
+
+export const collectDashboardPayload = (
+  filteredOrders: Order[],
+  filteredMovements: Movement[],
+  currentProducts: Product[]
+): DashboardPayload => ({
+  orders: filteredOrders,
+  movements: filteredMovements,
+  products: currentProducts,
+  orderStatusSummary: buildOrderStatusSummary(filteredOrders),
+  topProducts: buildTopProducts(filteredOrders),
+  billingBreakdown: buildBillingBreakdown(filteredOrders)
+});
+
+export const buildOrderStatusSummary = (items: Order[]): OrderStatusSummaryItem[] => {
+  const summary = new Map<OrderStatus, number>();
+
+  items.forEach((order) => {
+    summary.set(order.status, (summary.get(order.status) ?? 0) + 1);
+  });
+
+  return Array.from(summary.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([status, value]) => ({ status, value }));
+};
+
+export const buildTopProducts = (items: Order[]): TopProductSummary[] => {
+  const stats = new Map<string, TopProductSummary>();
+
+  items.forEach((order) => {
+    const entry = stats.get(order.product);
+    if (entry) {
+      entry.units += 1;
+      entry.revenue += order.salePrice;
+    } else {
+      stats.set(order.product, { product: order.product, units: 1, revenue: order.salePrice });
+    }
+  });
+
+  return Array.from(stats.values()).sort((a, b) => b.units - a.units);
+};
+
+export const buildBillingBreakdown = (items: Order[]): BillingBreakdownItem[] => {
+  if (!items.length) {
+    return [
+      { name: 'Facturación total', value: 0 },
+      { name: 'Costos de producto', value: 0 },
+      { name: 'Comisiones plataforma', value: 0 },
+      { name: 'Comisión COD', value: 0 },
+      { name: 'Envíos', value: 0 },
+      { name: 'Ganancia neta', value: 0 }
+    ];
+  }
+
+  const totalRevenue = items.reduce((acc, order) => acc + order.salePrice, 0);
+  const productCosts = items.reduce((acc, order) => acc + order.cost, 0);
+  const shippingCosts = items.reduce((acc, order) => acc + order.shippingCost, 0);
+  const platformFees = totalRevenue * 0.05;
+  const codCommission = items
+    .filter((order) => order.paymentMethod === 'COD')
+    .reduce((acc, order) => acc + order.salePrice * 0.03, 0);
+  const netProfit = totalRevenue - productCosts - shippingCosts - platformFees - codCommission;
+
+  return [
+    { name: 'Facturación total', value: Number(totalRevenue.toFixed(2)) },
+    { name: 'Costos de producto', value: Number(productCosts.toFixed(2)) },
+    { name: 'Comisiones plataforma', value: Number(platformFees.toFixed(2)) },
+    { name: 'Comisión COD', value: Number(codCommission.toFixed(2)) },
+    { name: 'Envíos', value: Number(shippingCosts.toFixed(2)) },
+    { name: 'Ganancia neta', value: Number(netProfit.toFixed(2)) }
+  ];
+};

--- a/latin-ecom-backend/src/routes.ts
+++ b/latin-ecom-backend/src/routes.ts
@@ -1,0 +1,245 @@
+import { Router } from 'express';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+import {
+  buildBillingBreakdown,
+  collectDashboardPayload,
+  connections,
+  movements,
+  orders,
+  products,
+  walletRequests
+} from './data.js';
+import { isWithinRange, normalizeSearch, parseDate } from './utils.js';
+import { Order } from './types.js';
+
+const router = Router();
+
+const orderInputSchema = z.object({
+  store: z.string().min(1),
+  product: z.string().min(1),
+  customer: z.string().min(1),
+  status: z
+    .union([
+      z.literal('Pendiente'),
+      z.literal('Registrar pago'),
+      z.literal('Confirmado'),
+      z.literal('Preparado'),
+      z.literal('Despachado'),
+      z.literal('Entregado'),
+      z.literal('En revisión'),
+      z.literal('Cancelado')
+    ])
+    .default('Pendiente'),
+  paymentMethod: z.union([z.literal('TC'), z.literal('COD')]),
+  cost: z.number().positive(),
+  shippingCost: z.number().min(0),
+  salePrice: z.number().positive(),
+  trackingCode: z.string().optional()
+});
+
+const statusUpdateSchema = z.object({
+  status: orderInputSchema.shape.status.optional(),
+  trackingCode: z.string().optional()
+});
+
+const walletStatusUpdateSchema = z.object({
+  status: z.union([z.literal('Pendiente'), z.literal('Aprobada'), z.literal('Rechazada')])
+});
+
+const connectionUpdateSchema = z.object({
+  status: z.union([z.literal('Activa'), z.literal('Sincronizando'), z.literal('Error')]).optional(),
+  lastSync: z.string().datetime().optional()
+});
+
+const toOrderResponse = (order: Order) => ({ data: order });
+
+router.get('/products', (req, res) => {
+  const { category, provider, search } = req.query as Record<string, string | undefined>;
+  const searchValue = search ? normalizeSearch(search) : undefined;
+
+  const filtered = products.filter((product) => {
+    const matchesCategory = !category || product.category === category;
+    const matchesProvider = !provider || product.provider === provider;
+    const matchesSearch =
+      !searchValue ||
+      normalizeSearch(product.name).includes(searchValue) ||
+      normalizeSearch(product.provider).includes(searchValue);
+    return matchesCategory && matchesProvider && matchesSearch;
+  });
+
+  res.json({ data: filtered });
+});
+
+router.get('/orders', (req, res) => {
+  const { status, paymentMethod, search, from, to } = req.query as Record<string, string | undefined>;
+  const fromDate = parseDate(from);
+  const toDate = parseDate(to);
+  const normalizedSearch = search ? normalizeSearch(search) : undefined;
+
+  const filtered = orders.filter((order) => {
+    const orderDate = new Date(order.createdAt);
+    const matchesStatus = !status || order.status === status;
+    const matchesPayment = !paymentMethod || order.paymentMethod === paymentMethod;
+    const matchesSearch =
+      !normalizedSearch ||
+      normalizeSearch(order.customer).includes(normalizedSearch) ||
+      normalizeSearch(order.product).includes(normalizedSearch) ||
+      normalizeSearch(order.id).includes(normalizedSearch);
+    const matchesRange = isWithinRange(orderDate, fromDate, toDate);
+    return matchesStatus && matchesPayment && matchesSearch && matchesRange;
+  });
+
+  res.json({ data: filtered.sort((a, b) => b.createdAt.localeCompare(a.createdAt)) });
+});
+
+router.get('/orders/:id', (req, res) => {
+  const order = orders.find((item) => item.id === req.params.id);
+  if (!order) {
+    res.status(404).json({ error: 'Pedido no encontrado' });
+    return;
+  }
+
+  res.json(toOrderResponse(order));
+});
+
+router.post('/orders', (req, res) => {
+  const parsed = orderInputSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.flatten() });
+    return;
+  }
+
+  const now = new Date();
+  const newOrder: Order = {
+    id: `ORD-${nanoid(6).toUpperCase()}`,
+    ...parsed.data,
+    createdAt: now.toISOString()
+  };
+
+  orders.unshift(newOrder);
+  res.status(201).json(toOrderResponse(newOrder));
+});
+
+router.patch('/orders/:id/status', (req, res) => {
+  const order = orders.find((item) => item.id === req.params.id);
+  if (!order) {
+    res.status(404).json({ error: 'Pedido no encontrado' });
+    return;
+  }
+
+  const parsed = statusUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.flatten() });
+    return;
+  }
+
+  if (parsed.data.status) {
+    order.status = parsed.data.status;
+  }
+  if (parsed.data.trackingCode) {
+    order.trackingCode = parsed.data.trackingCode;
+  }
+
+  res.json(toOrderResponse(order));
+});
+
+router.get('/movements', (req, res) => {
+  const { type, category, from, to } = req.query as Record<string, string | undefined>;
+  const fromDate = parseDate(from);
+  const toDate = parseDate(to);
+
+  const filtered = movements.filter((movement) => {
+    const movementDate = new Date(movement.date);
+    const matchesType = !type || movement.type === type;
+    const matchesCategory = !category || movement.category === category;
+    const matchesRange = isWithinRange(movementDate, fromDate, toDate);
+    return matchesType && matchesCategory && matchesRange;
+  });
+
+  res.json({ data: filtered.sort((a, b) => b.date.localeCompare(a.date)) });
+});
+
+router.get('/wallet-requests', (req, res) => {
+  const { status, type } = req.query as Record<string, string | undefined>;
+  const filtered = walletRequests.filter((request) => {
+    const matchesStatus = !status || request.status === status;
+    const matchesType = !type || request.type === type;
+    return matchesStatus && matchesType;
+  });
+
+  res.json({ data: filtered.sort((a, b) => b.createdAt.localeCompare(a.createdAt)) });
+});
+
+router.patch('/wallet-requests/:id/status', (req, res) => {
+  const request = walletRequests.find((item) => item.id === req.params.id);
+  if (!request) {
+    res.status(404).json({ error: 'Solicitud no encontrada' });
+    return;
+  }
+
+  const parsed = walletStatusUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.flatten() });
+    return;
+  }
+
+  request.status = parsed.data.status;
+  if (parsed.data.status !== 'Pendiente') {
+    request.processedAt = new Date().toISOString();
+  }
+
+  res.json({ data: request });
+});
+
+router.get('/connections', (req, res) => {
+  const { status } = req.query as Record<string, string | undefined>;
+  const filtered = connections.filter((connection) => !status || connection.status === status);
+  res.json({ data: filtered });
+});
+
+router.patch('/connections/:id', (req, res) => {
+  const connection = connections.find((item) => item.id === req.params.id);
+  if (!connection) {
+    res.status(404).json({ error: 'Conexión no encontrada' });
+    return;
+  }
+
+  const parsed = connectionUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.flatten() });
+    return;
+  }
+
+  if (parsed.data.status) {
+    connection.status = parsed.data.status;
+  }
+  if (parsed.data.lastSync) {
+    connection.lastSync = parsed.data.lastSync;
+  }
+
+  res.json({ data: connection });
+});
+
+router.get('/dashboard', (req, res) => {
+  const { from, to } = req.query as Record<string, string | undefined>;
+  const fromDate = parseDate(from);
+  const toDate = parseDate(to);
+
+  const filteredOrders = orders.filter((order) => isWithinRange(new Date(order.createdAt), fromDate, toDate));
+  const filteredMovements = movements.filter((movement) => isWithinRange(new Date(movement.date), fromDate, toDate));
+  const sortedProducts = [...products].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+  res.json({ data: collectDashboardPayload(filteredOrders, filteredMovements, sortedProducts) });
+});
+
+router.get('/billing', (req, res) => {
+  const { from, to } = req.query as Record<string, string | undefined>;
+  const fromDate = parseDate(from);
+  const toDate = parseDate(to);
+
+  const filteredOrders = orders.filter((order) => isWithinRange(new Date(order.createdAt), fromDate, toDate));
+  res.json({ data: buildBillingBreakdown(filteredOrders) });
+});
+
+export default router;

--- a/latin-ecom-backend/src/server.ts
+++ b/latin-ecom-backend/src/server.ts
@@ -1,0 +1,23 @@
+import express from 'express';
+import cors from 'cors';
+import router from './routes.js';
+
+const app = express();
+const PORT = Number(process.env.PORT ?? 4000);
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.use('/api', router);
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`Latin Ecom backend listening on port ${PORT}`);
+  });
+}
+
+export default app;

--- a/latin-ecom-backend/src/types.ts
+++ b/latin-ecom-backend/src/types.ts
@@ -70,7 +70,7 @@ export interface OrderStatusSummaryItem {
   value: number;
 }
 
-export interface TopProductSummaryItem {
+export interface TopProductSummary {
   product: string;
   units: number;
   revenue: number;
@@ -81,19 +81,11 @@ export interface BillingBreakdownItem {
   value: number;
 }
 
-export interface DashboardResponse {
+export interface DashboardPayload {
   orders: Order[];
   movements: Movement[];
   products: Product[];
   orderStatusSummary: OrderStatusSummaryItem[];
-  topProducts: TopProductSummaryItem[];
+  topProducts: TopProductSummary[];
   billingBreakdown: BillingBreakdownItem[];
-}
-
-export interface ApiListResponse<T> {
-  data: T;
-}
-
-export interface ApiItemResponse<T> {
-  data: T;
 }

--- a/latin-ecom-backend/src/utils.ts
+++ b/latin-ecom-backend/src/utils.ts
@@ -1,0 +1,15 @@
+import { parseISO } from 'date-fns';
+
+export const parseDate = (value?: string) => {
+  if (!value) return undefined;
+  const parsed = parseISO(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+export const isWithinRange = (date: Date, from?: Date, to?: Date) => {
+  if (from && date < from) return false;
+  if (to && date > to) return false;
+  return true;
+};
+
+export const normalizeSearch = (value: string) => value.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();

--- a/latin-ecom-backend/tsconfig.json
+++ b/latin-ecom-backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/latin-ecom/.env.example
+++ b/latin-ecom/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:4000

--- a/latin-ecom/src/api/client.ts
+++ b/latin-ecom/src/api/client.ts
@@ -1,0 +1,47 @@
+import { ApiError } from '../utils/errors';
+
+type RequestOptions = RequestInit & { query?: Record<string, string | number | boolean | undefined> };
+
+const baseUrl = (import.meta.env.VITE_API_URL ?? 'http://localhost:4000').replace(/\/$/, '');
+
+const buildUrl = (path: string, query?: RequestOptions['query']) => {
+  const url = new URL(`${baseUrl}${path}`);
+  if (query) {
+    Object.entries(query).forEach(([key, value]) => {
+      if (value === undefined || value === null || value === '') return;
+      url.searchParams.set(key, String(value));
+    });
+  }
+  return url.toString();
+};
+
+async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { query, headers, ...rest } = options;
+  const response = await fetch(buildUrl(path, query), {
+    ...rest,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers
+    }
+  });
+
+  if (!response.ok) {
+    let details: unknown;
+    try {
+      details = await response.json();
+    } catch (error) {
+      details = undefined;
+    }
+    throw new ApiError(response.statusText || 'Error en la solicitud', response.status, details);
+  }
+
+  return (await response.json()) as T;
+}
+
+export const apiClient = {
+  get: request,
+  post: <T>(path: string, body: unknown) => request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: unknown) => request<T>(path, { method: 'PATCH', body: JSON.stringify(body) })
+};
+
+export type { RequestOptions };

--- a/latin-ecom/src/api/hooks.ts
+++ b/latin-ecom/src/api/hooks.ts
@@ -1,0 +1,62 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from './client';
+import {
+  ApiItemResponse,
+  ApiListResponse,
+  BillingBreakdownItem,
+  Connection,
+  DashboardResponse,
+  Movement,
+  Order,
+  Product,
+  WalletRequest
+} from '../utils/types';
+
+export const useDashboard = (params?: { from?: string; to?: string }) =>
+  useQuery({
+    queryKey: ['dashboard', params],
+    queryFn: () => apiClient.get<ApiItemResponse<DashboardResponse>>('/api/dashboard', { query: params }),
+    select: (response) => response.data
+  });
+
+export const useProducts = () =>
+  useQuery({
+    queryKey: ['products'],
+    queryFn: () => apiClient.get<ApiListResponse<Product[]>>('/api/products'),
+    select: (response) => response.data
+  });
+
+export const useOrders = (params?: { status?: string; paymentMethod?: string; search?: string }) =>
+  useQuery({
+    queryKey: ['orders', params],
+    queryFn: () => apiClient.get<ApiListResponse<Order[]>>('/api/orders', { query: params }),
+    select: (response) => response.data
+  });
+
+export const useMovements = () =>
+  useQuery({
+    queryKey: ['movements'],
+    queryFn: () => apiClient.get<ApiListResponse<Movement[]>>('/api/movements'),
+    select: (response) => response.data
+  });
+
+export const useWalletRequests = () =>
+  useQuery({
+    queryKey: ['wallet-requests'],
+    queryFn: () => apiClient.get<ApiListResponse<WalletRequest[]>>('/api/wallet-requests'),
+    select: (response) => response.data
+  });
+
+export const useConnections = () =>
+  useQuery({
+    queryKey: ['connections'],
+    queryFn: () => apiClient.get<ApiListResponse<Connection[]>>('/api/connections'),
+    select: (response) => response.data
+  });
+
+export const useBillingBreakdown = (params?: { from?: string; to?: string }) =>
+  useQuery({
+    queryKey: ['billing', params],
+    queryFn: () => apiClient.get<ApiListResponse<BillingBreakdownItem[]>>('/api/billing', { query: params }),
+    select: (response) => response.data
+  });

--- a/latin-ecom/src/components/ErrorState.tsx
+++ b/latin-ecom/src/components/ErrorState.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+
+interface ErrorStateProps {
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+const ErrorState = ({
+  title = 'No pudimos cargar la información',
+  description = 'Revisa tu conexión o intenta nuevamente en unos segundos.',
+  onRetry,
+  className
+}: ErrorStateProps) => {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-danger/40 bg-white p-10 text-center text-danger shadow-sm',
+        className
+      )}
+    >
+      <p className="text-base font-semibold">{title}</p>
+      <p className="text-sm text-danger/80">{description}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="rounded-xl border border-danger px-4 py-2 text-xs font-semibold text-danger transition hover:bg-danger/10"
+        >
+          Reintentar
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ErrorState;

--- a/latin-ecom/src/components/LoadingState.tsx
+++ b/latin-ecom/src/components/LoadingState.tsx
@@ -1,0 +1,22 @@
+import clsx from 'clsx';
+
+interface LoadingStateProps {
+  message?: string;
+  className?: string;
+}
+
+const LoadingState = ({ message = 'Cargando datos...', className }: LoadingStateProps) => {
+  return (
+    <div
+      className={clsx(
+        'flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-200 bg-white p-10 text-center text-slate-500 shadow-sm',
+        className
+      )}
+    >
+      <span className="inline-flex h-10 w-10 animate-spin rounded-full border-2 border-slate-300 border-t-primary" />
+      <p className="text-sm font-medium text-secondary">{message}</p>
+    </div>
+  );
+};
+
+export default LoadingState;

--- a/latin-ecom/src/pages/AccountPage.tsx
+++ b/latin-ecom/src/pages/AccountPage.tsx
@@ -1,10 +1,22 @@
 import SectionCard from '../components/SectionCard';
-import { billingBreakdown } from '../data/mockData';
 import { useState } from 'react';
+import { useBillingBreakdown } from '../api/hooks';
+import LoadingState from '../components/LoadingState';
+import ErrorState from '../components/ErrorState';
 
 const AccountPage = () => {
+  const { data, isLoading, isError, refetch } = useBillingBreakdown();
+  const billingBreakdown = data ?? [];
   const [autoRecharge, setAutoRecharge] = useState(true);
   const [alerts, setAlerts] = useState({ balance: true, incidents: true, payouts: false });
+
+  if (isLoading) {
+    return <LoadingState message="Cargando configuración de cuenta..." />;
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => refetch()} />;
+  }
 
   return (
     <div className="space-y-6">

--- a/latin-ecom/src/pages/ConnectionsPage.tsx
+++ b/latin-ecom/src/pages/ConnectionsPage.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from 'react';
 import SectionCard from '../components/SectionCard';
-import { connections } from '../data/mockData';
 import { Link2, RefreshCw, PlugZap } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
+import { useConnections } from '../api/hooks';
+import LoadingState from '../components/LoadingState';
+import ErrorState from '../components/ErrorState';
 
 const statusClass = {
   Activa: 'text-success bg-success/10',
@@ -11,6 +14,17 @@ const statusClass = {
 } as const;
 
 const ConnectionsPage = () => {
+  const { data, isLoading, isError, refetch } = useConnections();
+  const connections = useMemo(() => data ?? [], [data]);
+
+  if (isLoading) {
+    return <LoadingState message="Cargando integraciones..." />;
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => refetch()} />;
+  }
+
   return (
     <div className="space-y-6">
       <SectionCard

--- a/latin-ecom/src/pages/HomePage.tsx
+++ b/latin-ecom/src/pages/HomePage.tsx
@@ -1,14 +1,7 @@
 import SectionCard from '../components/SectionCard';
 import StatCard from '../components/StatCard';
 import { Activity, Package, TrendingUp, Wallet } from 'lucide-react';
-import {
-  billingBreakdown,
-  movements,
-  orderStatusSummary,
-  orders,
-  products,
-  topProducts
-} from '../data/mockData';
+import { useDashboard } from '../api/hooks';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
 import {
@@ -24,13 +17,29 @@ import {
   XAxis,
   YAxis
 } from 'recharts';
+import LoadingState from '../components/LoadingState';
+import ErrorState from '../components/ErrorState';
 
 const chartColors = ['#1F7A8C', '#022B3A', '#EE6C4D', '#1EAE98', '#F4D35E', '#A1AEC4', '#9B287B', '#3A506B'];
 
 const HomePage = () => {
-  const deliveredRate = Math.round((orders.filter((o) => o.status === 'Entregado').length / orders.length) * 100);
-  const incidents = orders.filter((o) => ['En revisión', 'Registrar pago'].includes(o.status)).length;
-  const pendingToConfirm = orders.filter((o) => o.status === 'Pendiente').length;
+  const { data, isLoading, isError, refetch } = useDashboard();
+
+  if (isLoading) {
+    return <LoadingState message="Cargando resumen general..." />;
+  }
+
+  if (isError || !data) {
+    return <ErrorState onRetry={() => refetch()} />;
+  }
+
+  const { orders, movements, products, orderStatusSummary, topProducts, billingBreakdown } = data;
+
+  const deliveredRate = orders.length
+    ? Math.round((orders.filter((order) => order.status === 'Entregado').length / orders.length) * 100)
+    : 0;
+  const incidents = orders.filter((order) => ['En revisión', 'Registrar pago'].includes(order.status)).length;
+  const pendingToConfirm = orders.filter((order) => order.status === 'Pendiente').length;
   const walletBalance = movements.reduce((acc, mov) => acc + mov.amount, 3450);
 
   return (

--- a/latin-ecom/src/pages/ProductsPage.tsx
+++ b/latin-ecom/src/pages/ProductsPage.tsx
@@ -1,16 +1,27 @@
 import { useMemo, useState } from 'react';
 import SectionCard from '../components/SectionCard';
-import { products } from '../data/mockData';
 import { Star, Filter, Search } from 'lucide-react';
+import { useProducts } from '../api/hooks';
+import LoadingState from '../components/LoadingState';
+import ErrorState from '../components/ErrorState';
+import { Product } from '../utils/types';
 
 const uniqueValues = (items: string[]) => Array.from(new Set(items)).sort();
 
 const ProductsPage = () => {
+  const { data, isLoading, isError, refetch } = useProducts();
+  const products = useMemo(() => data ?? [], [data]);
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState('Todas');
   const [provider, setProvider] = useState('Todos');
-  const categories = useMemo(() => ['Todas', ...uniqueValues(products.map((p) => p.category))], []);
-  const providers = useMemo(() => ['Todos', ...uniqueValues(products.map((p) => p.provider))], []);
+  const categories = useMemo(
+    () => ['Todas', ...uniqueValues(products.map((product: Product) => product.category))],
+    [products]
+  );
+  const providers = useMemo(
+    () => ['Todos', ...uniqueValues(products.map((product: Product) => product.provider))],
+    [products]
+  );
 
   const filtered = useMemo(() => {
     return products.filter((product) => {
@@ -19,7 +30,15 @@ const ProductsPage = () => {
       const matchesProvider = provider === 'Todos' || product.provider === provider;
       return matchesSearch && matchesCategory && matchesProvider;
     });
-  }, [category, provider, search]);
+  }, [category, products, provider, search]);
+
+  if (isLoading) {
+    return <LoadingState message="Cargando catálogo de productos..." />;
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => refetch()} />;
+  }
 
   return (
     <SectionCard

--- a/latin-ecom/src/pages/RequestsPage.tsx
+++ b/latin-ecom/src/pages/RequestsPage.tsx
@@ -1,9 +1,11 @@
 import SectionCard from '../components/SectionCard';
-import { walletRequests } from '../data/mockData';
 import { useMemo, useState } from 'react';
 import { es } from 'date-fns/locale';
 import { format } from 'date-fns';
 import { CircleCheck, CircleDashed, CircleX, PlusCircle } from 'lucide-react';
+import { useWalletRequests } from '../api/hooks';
+import LoadingState from '../components/LoadingState';
+import ErrorState from '../components/ErrorState';
 
 const statusStyles = {
   Pendiente: 'bg-warning/10 text-warning',
@@ -12,11 +14,21 @@ const statusStyles = {
 } as const;
 
 const RequestsPage = () => {
+  const { data, isLoading, isError, refetch } = useWalletRequests();
+  const walletRequests = useMemo(() => data ?? [], [data]);
   const [statusFilter, setStatusFilter] = useState<'Todas' | keyof typeof statusStyles>('Todas');
 
   const filtered = useMemo(() => {
     return walletRequests.filter((request) => statusFilter === 'Todas' || request.status === statusFilter);
-  }, [statusFilter]);
+  }, [statusFilter, walletRequests]);
+
+  if (isLoading) {
+    return <LoadingState message="Cargando solicitudes financieras..." />;
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => refetch()} />;
+  }
 
   return (
     <SectionCard

--- a/latin-ecom/src/utils/errors.ts
+++ b/latin-ecom/src/utils/errors.ts
@@ -1,0 +1,11 @@
+export class ApiError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.details = details;
+  }
+}


### PR DESCRIPTION
## Summary
- add a TypeScript Express backend that exposes resources for products, orders, wallet requests, connections and dashboard analytics
- replace mocked frontend data with React Query hooks that consume the new API and show loading/error feedback states
- document the monorepo workflow and provide environment configuration helpers for local development

## Testing
- npm run build (latin-ecom-backend)
- npm run lint (latin-ecom)


------
https://chatgpt.com/codex/tasks/task_e_68e42cb2401483288679007f54264020