### PR TITLE
Add comprehensive unit and E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,14 @@ npm run build
 # Frontend: ejecutar linter
 npm run lint
 
-# Frontend: ejecutar pruebas (vitest)
-npm test
+# Frontend: ejecutar pruebas unitarias con cobertura
+npm run test:unit
+
+# Frontend: ejecutar pruebas end-to-end con Playwright
+npm run test:e2e
+
+# Frontend: ejecutar todo el set de pruebas
+npm run test:all
 ```
 
 ## Estructura

--- a/latin-ecom/.gitignore
+++ b/latin-ecom/.gitignore
@@ -3,3 +3,5 @@ node_modules
 dist
 .vite
 coverage
+playwright-report
+test-results

--- a/latin-ecom/package-lock.json
+++ b/latin-ecom/package-lock.json
@@ -19,22 +19,35 @@
         "recharts": "2.12.7"
       },
       "devDependencies": {
+        "@playwright/test": "1.48.2",
+        "@testing-library/jest-dom": "6.5.0",
+        "@testing-library/react": "16.0.1",
+        "@testing-library/user-event": "14.5.2",
         "@types/react": "18.3.7",
         "@types/react-dom": "18.3.3",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
         "@vitejs/plugin-react": "4.3.3",
+        "@vitest/coverage-v8": "2.1.5",
         "autoprefixer": "10.4.20",
         "eslint": "8.57.1",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-react-hooks": "5.1.0-rc.0",
         "eslint-plugin-react-refresh": "0.4.12",
+        "jsdom": "25.0.0",
         "postcss": "8.4.49",
         "tailwindcss": "3.4.15",
         "typescript": "5.6.3",
         "vite": "5.4.10",
         "vitest": "2.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -48,6 +61,41 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -358,6 +406,128 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -947,6 +1117,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1044,6 +1224,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
+      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.48.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1422,6 +1618,119 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.5.0.tgz",
+      "integrity": "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "lodash": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
+      "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1785,6 +2094,39 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.5.tgz",
+      "integrity": "sha512-/RoopB7XGW7UEkUndRXF87A9CwkoZAJW01pj8/3pgmDVsjMH2IKy6H1A38po9tmUlwhSyYs0az82rbKd9Yaynw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.5",
+        "vitest": "2.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.5.tgz",
@@ -1947,6 +2289,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2025,6 +2377,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -2044,6 +2406,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -2178,6 +2547,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2332,6 +2715,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2371,6 +2767,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2383,6 +2786,27 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -2511,6 +2935,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/date-fns": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
@@ -2539,6 +2977,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2561,6 +3006,26 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2602,6 +3067,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -2610,6 +3083,21 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -2633,12 +3121,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -3091,6 +3641,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -3145,6 +3712,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -3243,6 +3849,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -3260,6 +3879,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3271,6 +3919,67 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3308,6 +4017,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3420,12 +4139,73 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3470,6 +4250,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.0.tgz",
+      "integrity": "sha512-OhoFVT59T7aEq75TVw9xxEfkXgacpqAhQaYgP9y/fDqWQCMB/b1H66RfmPm/MaeaAIU9nDwMOVTlPN51+ao6CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3627,6 +4448,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -3635,6 +4467,44 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge2": {
@@ -3659,6 +4529,39 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3759,6 +4662,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3856,6 +4766,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3984,6 +4907,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.48.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -4165,6 +5135,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4176,6 +5184,19 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4185,6 +5206,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4366,6 +5394,27 @@
         "decimal.js-light": "^2.4.1"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -4467,6 +5516,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4489,6 +5545,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4687,6 +5763,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4770,6 +5859,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.15",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
@@ -4806,6 +5902,42 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {
@@ -4901,6 +6033,35 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -4961,6 +6122,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -5000,6 +6171,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5180,6 +6362,66 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5330,6 +6572,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/latin-ecom/package.json
+++ b/latin-ecom/package.json
@@ -8,7 +8,10 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --max-warnings=0",
-    "test": "vitest"
+    "test": "vitest",
+    "test:unit": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:all": "npm run test:unit && npm run test:e2e"
   },
   "dependencies": {
     "@tanstack/react-query": "5.64.2",
@@ -24,6 +27,11 @@
   "devDependencies": {
     "@types/react": "18.3.7",
     "@types/react-dom": "18.3.3",
+    "@playwright/test": "1.48.2",
+    "@testing-library/jest-dom": "6.5.0",
+    "@testing-library/react": "16.0.1",
+    "@testing-library/user-event": "14.5.2",
+    "@vitest/coverage-v8": "2.1.5",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "@vitejs/plugin-react": "4.3.3",
@@ -36,6 +44,7 @@
     "tailwindcss": "3.4.15",
     "typescript": "5.6.3",
     "vite": "5.4.10",
-    "vitest": "2.1.5"
+    "vitest": "2.1.5",
+    "jsdom": "25.0.0"
   }
 }

--- a/latin-ecom/playwright.config.ts
+++ b/latin-ecom/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 5_000
+  },
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    ...devices['Desktop Chrome']
+  },
+  webServer: {
+    command: 'npm run dev -- --host 0.0.0.0 --port 5173',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe'
+  }
+});

--- a/latin-ecom/src/__tests__/AccountPage.test.tsx
+++ b/latin-ecom/src/__tests__/AccountPage.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AccountPage from '../pages/AccountPage';
+import { vi } from 'vitest';
+import { billingBreakdown } from '../test/fixtures';
+
+vi.mock('../api/hooks', () => ({
+  useBillingBreakdown: vi.fn()
+}));
+
+const { useBillingBreakdown } = await import('../api/hooks');
+const useBillingBreakdownMock = vi.mocked(useBillingBreakdown);
+
+describe('AccountPage', () => {
+  beforeEach(() => {
+    useBillingBreakdownMock.mockReset();
+  });
+
+  it('muestra el estado de carga', () => {
+    useBillingBreakdownMock.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() });
+    render(<AccountPage />);
+
+    expect(screen.getByText('Cargando configuración de cuenta...')).toBeInTheDocument();
+  });
+
+  it('permite reintentar cuando ocurre un error', () => {
+    const refetch = vi.fn();
+    useBillingBreakdownMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch });
+    render(<AccountPage />);
+
+    screen.getByRole('button', { name: 'Reintentar' }).click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('muestra la configuración y permite modificar switches y checkboxes', async () => {
+    useBillingBreakdownMock.mockReturnValue({ isLoading: false, isError: false, data: billingBreakdown, refetch: vi.fn() });
+    render(<AccountPage />);
+    const user = userEvent.setup();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    const [autoRecharge, ...alertCheckboxes] = checkboxes;
+    expect(autoRecharge).toBeChecked();
+    await user.click(autoRecharge);
+    expect(autoRecharge).not.toBeChecked();
+
+    expect(alertCheckboxes).toHaveLength(3);
+    for (const checkbox of alertCheckboxes) {
+      await user.click(checkbox);
+    }
+
+    billingBreakdown.forEach((item) => {
+      expect(screen.getByText(item.name)).toBeInTheDocument();
+    });
+  });
+});

--- a/latin-ecom/src/__tests__/ConnectionsPage.test.tsx
+++ b/latin-ecom/src/__tests__/ConnectionsPage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConnectionsPage from '../pages/ConnectionsPage';
+import { vi } from 'vitest';
+import { connections, orders } from '../test/fixtures';
+
+vi.mock('../api/hooks', () => ({
+  useConnections: vi.fn(),
+  useOrders: vi.fn()
+}));
+
+const { useConnections, useOrders } = await import('../api/hooks');
+const useConnectionsMock = vi.mocked(useConnections);
+const useOrdersMock = vi.mocked(useOrders);
+
+describe('ConnectionsPage', () => {
+  beforeEach(() => {
+    useConnectionsMock.mockReset();
+    useOrdersMock.mockReset();
+  });
+
+  it('muestra el estado de carga cuando las consultas siguen en progreso', () => {
+    useConnectionsMock.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() });
+    useOrdersMock.mockReturnValue({ isLoading: false, isError: false, data: orders, refetch: vi.fn() });
+
+    render(<ConnectionsPage />);
+    expect(screen.getByText('Cargando integraciones...')).toBeInTheDocument();
+  });
+
+  it('permite reintentar cuando alguna consulta falla', () => {
+    const refetchConnections = vi.fn();
+    const refetchOrders = vi.fn();
+    useConnectionsMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch: refetchConnections });
+    useOrdersMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch: refetchOrders });
+
+    render(<ConnectionsPage />);
+    const retry = screen.getByRole('button', { name: 'Reintentar' });
+    retry.click();
+
+    expect(refetchConnections).toHaveBeenCalledTimes(1);
+    expect(refetchOrders).toHaveBeenCalledTimes(1);
+  });
+
+  it('renderiza las conexiones y mantiene habilitados los botones clave', async () => {
+    useConnectionsMock.mockReturnValue({ isLoading: false, isError: false, data: connections, refetch: vi.fn() });
+    useOrdersMock.mockReturnValue({ isLoading: false, isError: false, data: orders, refetch: vi.fn() });
+
+    render(<ConnectionsPage />);
+
+    expect(screen.getByRole('button', { name: 'Conectar nueva tienda' })).toBeEnabled();
+    expect(screen.getAllByRole('button', { name: 'Sincronizar ahora' })).toHaveLength(connections.length);
+    expect(screen.getAllByRole('button', { name: 'Ver pedidos sincronizados' })).toHaveLength(connections.length);
+
+    const user = userEvent.setup();
+    await user.click(screen.getAllByRole('button', { name: 'Sincronizar ahora' })[0]);
+    await user.click(screen.getAllByRole('button', { name: 'Ver pedidos sincronizados' })[0]);
+
+    expect(screen.getByText('Estado de integraciones')).toBeInTheDocument();
+    expect(screen.getByText('Integraciones activas')).toBeInTheDocument();
+  });
+});

--- a/latin-ecom/src/__tests__/DashboardLayout.test.tsx
+++ b/latin-ecom/src/__tests__/DashboardLayout.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import DashboardLayout from '../layouts/DashboardLayout';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+
+const renderWithRouter = (initialPath = '/') =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <DashboardLayout>
+        <div>Contenido de prueba</div>
+      </DashboardLayout>
+    </MemoryRouter>
+  );
+
+describe('DashboardLayout', () => {
+  it('muestra todos los enlaces de navegación y el contenido hijo', () => {
+    renderWithRouter('/productos');
+
+    const links = [
+      'Dashboard',
+      'Productos',
+      'Pedidos',
+      'Conexiones',
+      'Movimientos',
+      'Solicitudes',
+      'Mi cuenta',
+      'Mi perfil'
+    ];
+
+    links.forEach((link) => {
+      expect(screen.getByRole('link', { name: link })).toBeVisible();
+    });
+
+    expect(screen.getByText('Contenido de prueba')).toBeInTheDocument();
+  });
+
+  it('resalta el enlace correspondiente a la ruta activa', () => {
+    renderWithRouter('/pedidos');
+
+    const activeLink = screen.getByRole('link', { name: 'Pedidos' });
+    expect(activeLink).toHaveAttribute('class', expect.stringContaining('bg-primary/10'));
+  });
+
+  it('permite alternar la visibilidad del menú lateral en pantallas pequeñas', async () => {
+    renderWithRouter('/');
+    const user = userEvent.setup();
+    const toggleButton = screen.getByRole('button', { name: 'Cerrar menú de navegación' });
+
+    const sidebar = screen.getByRole('complementary');
+    expect(sidebar).toHaveAttribute('class', expect.stringContaining('translate-x-0'));
+
+    await user.click(toggleButton);
+    expect(toggleButton).toHaveAttribute('aria-label', 'Abrir menú de navegación');
+    expect(sidebar).toHaveAttribute('class', expect.stringContaining('-translate-x-full'));
+  });
+});

--- a/latin-ecom/src/__tests__/HomePage.test.tsx
+++ b/latin-ecom/src/__tests__/HomePage.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, within } from '@testing-library/react';
+import HomePage from '../pages/HomePage';
+import { vi } from 'vitest';
+import { dashboardResponse } from '../test/fixtures';
+
+vi.mock('../api/hooks', () => ({
+  useDashboard: vi.fn()
+}));
+
+const { useDashboard } = await import('../api/hooks');
+const useDashboardMock = vi.mocked(useDashboard);
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    useDashboardMock.mockReset();
+  });
+
+  it('muestra el estado de carga', () => {
+    useDashboardMock.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() });
+    render(<HomePage />);
+
+    expect(screen.getByText('Cargando resumen general...')).toBeInTheDocument();
+  });
+
+  it('muestra el estado de error con botón de reintento', async () => {
+    const refetch = vi.fn();
+    useDashboardMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch });
+    render(<HomePage />);
+
+    const retryButton = screen.getByRole('button', { name: 'Reintentar' });
+    expect(retryButton).toBeInTheDocument();
+    retryButton.click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('renderiza los resúmenes del dashboard con los datos correctos', () => {
+    useDashboardMock.mockReturnValue({ isLoading: false, isError: false, data: dashboardResponse, refetch: vi.fn() });
+    render(<HomePage />);
+
+    expect(screen.getByText('Pedidos entregados')).toBeVisible();
+    expect(screen.getByText('Pedidos con incidencias')).toBeVisible();
+    expect(screen.getByText('Pendientes por confirmar')).toBeVisible();
+    expect(screen.getByText('Saldo billetera')).toBeVisible();
+    expect(screen.getByText('Top productos')).toBeVisible();
+    expect(screen.getByText('Facturación')).toBeVisible();
+    expect(screen.getByText('Timeline de actividad')).toBeVisible();
+
+    const topProductsSection = screen.getByRole('heading', { name: 'Top productos' }).closest('section');
+    expect(topProductsSection).not.toBeNull();
+    dashboardResponse.topProducts.forEach((item) => {
+      expect(within(topProductsSection as HTMLElement).getByText(item.product)).toBeInTheDocument();
+    });
+  });
+});

--- a/latin-ecom/src/__tests__/MovementsPage.test.tsx
+++ b/latin-ecom/src/__tests__/MovementsPage.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MovementsPage from '../pages/MovementsPage';
+import { vi } from 'vitest';
+import { movements } from '../test/fixtures';
+
+vi.mock('../api/hooks', () => ({
+  useMovements: vi.fn()
+}));
+
+const { useMovements } = await import('../api/hooks');
+const useMovementsMock = vi.mocked(useMovements);
+
+describe('MovementsPage', () => {
+  beforeEach(() => {
+    useMovementsMock.mockReset();
+  });
+
+  it('muestra el estado de carga', () => {
+    useMovementsMock.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() });
+    render(<MovementsPage />);
+
+    expect(screen.getByText('Cargando movimientos...')).toBeInTheDocument();
+  });
+
+  it('permite reintentar cuando ocurre un error', () => {
+    const refetch = vi.fn();
+    useMovementsMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch });
+    render(<MovementsPage />);
+
+    screen.getByRole('button', { name: 'Reintentar' }).click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('filtra por tipo y categoría actualizando los totales', async () => {
+    useMovementsMock.mockReturnValue({ isLoading: false, isError: false, data: movements, refetch: vi.fn() });
+    render(<MovementsPage />);
+    const user = userEvent.setup();
+
+    const incomesCard = screen.getByText('Ingresos filtrados').closest('div');
+    const expensesCard = screen.getByText('Egresos filtrados').closest('div');
+    expect(incomesCard).not.toBeNull();
+    expect(expensesCard).not.toBeNull();
+
+    expect(within(incomesCard as HTMLElement).getByText(/1575\.00/)).toBeVisible();
+    expect(within(expensesCard as HTMLElement).getByText(/12\.00/)).toBeVisible();
+
+    await user.selectOptions(screen.getByLabelText('Tipo'), 'Ingreso');
+    expect(within(incomesCard as HTMLElement).getByText(/1575\.00/)).toBeVisible();
+    expect(within(expensesCard as HTMLElement).getByText(/0\.00/)).toBeVisible();
+
+    await user.selectOptions(screen.getByLabelText('Categoría'), 'Confirmación pedido');
+    expect(within(incomesCard as HTMLElement).getByText(/75\.00/)).toBeVisible();
+    expect(within(expensesCard as HTMLElement).getByText(/0\.00/)).toBeVisible();
+  });
+
+  it('mantiene accesibles los botones principales', () => {
+    useMovementsMock.mockReturnValue({ isLoading: false, isError: false, data: movements, refetch: vi.fn() });
+    render(<MovementsPage />);
+
+    expect(screen.getByRole('button', { name: 'Exportar CSV' })).toBeEnabled();
+  });
+});

--- a/latin-ecom/src/__tests__/OrdersPage.test.tsx
+++ b/latin-ecom/src/__tests__/OrdersPage.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OrdersPage from '../pages/OrdersPage';
+import { vi } from 'vitest';
+import { orders } from '../test/fixtures';
+
+vi.mock('../api/hooks', () => ({
+  useOrders: vi.fn()
+}));
+
+const { useOrders } = await import('../api/hooks');
+const useOrdersMock = vi.mocked(useOrders);
+
+describe('OrdersPage', () => {
+  beforeEach(() => {
+    useOrdersMock.mockReset();
+  });
+
+  it('muestra el estado de carga', () => {
+    useOrdersMock.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() });
+    render(<OrdersPage />);
+
+    expect(screen.getByText('Cargando pedidos...')).toBeInTheDocument();
+  });
+
+  it('permite reintentar al fallar la consulta', () => {
+    const refetch = vi.fn();
+    useOrdersMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch });
+    render(<OrdersPage />);
+
+    screen.getByRole('button', { name: 'Reintentar' }).click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('filtra por estado y método de pago y actualiza el detalle seleccionado', async () => {
+    useOrdersMock.mockReturnValue({ isLoading: false, isError: false, data: orders, refetch: vi.fn() });
+    render(<OrdersPage />);
+    const user = userEvent.setup();
+
+    const ordersTable = screen.getAllByRole('table')[0];
+    expect(within(ordersTable).getAllByRole('row').length).toBeGreaterThan(1);
+
+    const detailSection = screen.getByRole('heading', { name: 'Detalle del pedido' }).closest('section');
+    expect(detailSection).not.toBeNull();
+    expect(within(detailSection as HTMLElement).getByText('ORD-1001')).toBeInTheDocument();
+
+    await user.click(screen.getByText('ORD-1003'));
+    expect(within(detailSection as HTMLElement).getByText('ORD-1003')).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText('Estado'), 'Pendiente');
+    expect(within(ordersTable).getAllByRole('row')).toHaveLength(2);
+
+    await user.selectOptions(screen.getByLabelText('Método de pago'), 'COD');
+    expect(within(ordersTable).getAllByRole('row')).toHaveLength(2);
+    expect(within(detailSection as HTMLElement).getByText('ORD-1002')).toBeInTheDocument();
+  });
+
+  it('mantiene activos los botones de acciones rápidas', () => {
+    useOrdersMock.mockReturnValue({ isLoading: false, isError: false, data: orders, refetch: vi.fn() });
+    render(<OrdersPage />);
+
+    ['Confirmar pedido', 'Registrar pago manual', 'Reportar incidencia', 'Exportar reporte', 'Filtros avanzados'].forEach(
+      (label) => {
+        expect(screen.getByRole('button', { name: label })).toBeEnabled();
+      }
+    );
+  });
+});

--- a/latin-ecom/src/__tests__/ProductsPage.test.tsx
+++ b/latin-ecom/src/__tests__/ProductsPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProductsPage from '../pages/ProductsPage';
+import { vi } from 'vitest';
+import { products } from '../test/fixtures';
+
+vi.mock('../api/hooks', () => ({
+  useProducts: vi.fn()
+}));
+
+const { useProducts } = await import('../api/hooks');
+const useProductsMock = vi.mocked(useProducts);
+
+describe('ProductsPage', () => {
+  beforeEach(() => {
+    useProductsMock.mockReset();
+  });
+
+  it('muestra el estado de carga', () => {
+    useProductsMock.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() });
+    render(<ProductsPage />);
+
+    expect(screen.getByText('Cargando catálogo de productos...')).toBeInTheDocument();
+  });
+
+  it('permite reintentar cuando ocurre un error', () => {
+    const refetch = vi.fn();
+    useProductsMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch });
+    render(<ProductsPage />);
+
+    screen.getByRole('button', { name: 'Reintentar' }).click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('filtra la lista de productos por búsqueda, categoría y proveedor', async () => {
+    useProductsMock.mockReturnValue({ isLoading: false, isError: false, data: products, refetch: vi.fn() });
+    render(<ProductsPage />);
+    const user = userEvent.setup();
+
+    expect(screen.getAllByRole('article')).toHaveLength(products.length);
+
+    await user.type(screen.getByPlaceholderText('Nombre, categoría o proveedor'), 'vegana');
+    expect(screen.getAllByRole('article')).toHaveLength(1);
+    expect(screen.getByText('Proteína vegana cacao')).toBeVisible();
+
+    await user.clear(screen.getByPlaceholderText('Nombre, categoría o proveedor'));
+    await user.selectOptions(screen.getByLabelText('Categoría'), 'Fitness');
+    expect(screen.getAllByRole('article')).toHaveLength(1);
+    expect(screen.getByText('Kit de bandas elásticas')).toBeVisible();
+
+    await user.selectOptions(screen.getByLabelText('Proveedor'), 'HydrateX');
+    expect(screen.queryAllByRole('article')).toHaveLength(0);
+  });
+
+  it('mantiene accesibles los botones principales', () => {
+    useProductsMock.mockReturnValue({ isLoading: false, isError: false, data: products, refetch: vi.fn() });
+    render(<ProductsPage />);
+
+    expect(screen.getByRole('button', { name: 'Exportar CSV' })).toBeEnabled();
+    const addButtons = screen.getAllByRole('button', { name: 'Agregar a mi tienda' });
+    expect(addButtons).toHaveLength(products.length);
+    addButtons.forEach((button) => expect(button).toBeEnabled());
+  });
+});

--- a/latin-ecom/src/__tests__/ProfilePage.test.tsx
+++ b/latin-ecom/src/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProfilePage from '../pages/ProfilePage';
+
+describe('ProfilePage', () => {
+  it('permite editar los campos del perfil y acceder a las acciones principales', async () => {
+    render(<ProfilePage />);
+    const user = userEvent.setup();
+
+    const nameInput = screen.getByDisplayValue('Sofía Martínez');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Sofía M.');
+    expect(screen.getByDisplayValue('Sofía M.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Guardar cambios' }));
+    await user.click(screen.getByRole('button', { name: 'Activar por SMS' }));
+    await user.click(screen.getByRole('button', { name: 'Cerrar todas las sesiones' }));
+
+    expect(screen.getByText('Equipo y roles')).toBeInTheDocument();
+  });
+});

--- a/latin-ecom/src/__tests__/RequestsPage.test.tsx
+++ b/latin-ecom/src/__tests__/RequestsPage.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RequestsPage from '../pages/RequestsPage';
+import { vi } from 'vitest';
+import { walletRequests } from '../test/fixtures';
+
+vi.mock('../api/hooks', () => ({
+  useWalletRequests: vi.fn()
+}));
+
+const { useWalletRequests } = await import('../api/hooks');
+const useWalletRequestsMock = vi.mocked(useWalletRequests);
+
+describe('RequestsPage', () => {
+  beforeEach(() => {
+    useWalletRequestsMock.mockReset();
+  });
+
+  it('muestra el estado de carga', () => {
+    useWalletRequestsMock.mockReturnValue({ isLoading: true, isError: false, data: undefined, refetch: vi.fn() });
+    render(<RequestsPage />);
+
+    expect(screen.getByText('Cargando solicitudes financieras...')).toBeInTheDocument();
+  });
+
+  it('permite reintentar cuando ocurre un error', () => {
+    const refetch = vi.fn();
+    useWalletRequestsMock.mockReturnValue({ isLoading: false, isError: true, data: undefined, refetch });
+    render(<RequestsPage />);
+
+    screen.getByRole('button', { name: 'Reintentar' }).click();
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('filtra las solicitudes por estado', async () => {
+    useWalletRequestsMock.mockReturnValue({ isLoading: false, isError: false, data: walletRequests, refetch: vi.fn() });
+    render(<RequestsPage />);
+    const user = userEvent.setup();
+
+    expect(screen.getAllByRole('row')).toHaveLength(walletRequests.length + 1);
+
+    await user.click(screen.getByRole('button', { name: 'Pendientes' }));
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+    expect(screen.getByText('Recarga USDT Julio')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Aprobadas' }));
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+    expect(screen.getByText('Pago proveedor semana 29')).toBeVisible();
+  });
+
+  it('mantiene habilitados los botones de acciones principales', () => {
+    useWalletRequestsMock.mockReturnValue({ isLoading: false, isError: false, data: walletRequests, refetch: vi.fn() });
+    render(<RequestsPage />);
+
+    ['Ingresar dinero', 'Retirar dinero'].forEach((label) => {
+      expect(screen.getByRole('button', { name: label })).toBeEnabled();
+    });
+  });
+});

--- a/latin-ecom/src/layouts/DashboardLayout.tsx
+++ b/latin-ecom/src/layouts/DashboardLayout.tsx
@@ -60,6 +60,7 @@ const DashboardLayout = ({ children }: { children: ReactNode }) => {
               <button
                 type="button"
                 className="lg:hidden rounded-lg border border-slate-200 p-2 text-slate-600"
+                aria-label={isOpen ? 'Cerrar menú de navegación' : 'Abrir menú de navegación'}
                 onClick={() => setIsOpen((prev) => !prev)}
               >
                 <Menu size={18} />

--- a/latin-ecom/src/pages/MovementsPage.tsx
+++ b/latin-ecom/src/pages/MovementsPage.tsx
@@ -59,8 +59,11 @@ const MovementsPage = () => {
     >
       <div className="flex flex-wrap gap-4">
         <div>
-          <label className="text-xs font-semibold text-slate-500">Tipo</label>
+          <label className="text-xs font-semibold text-slate-500" htmlFor="movement-type-filter">
+            Tipo
+          </label>
           <select
+            id="movement-type-filter"
             value={typeFilter}
             onChange={(event) => setTypeFilter(event.target.value as (typeof typeOptions)[number])}
             className="mt-1 h-10 rounded-xl border border-slate-200 px-3 text-sm"
@@ -71,8 +74,11 @@ const MovementsPage = () => {
           </select>
         </div>
         <div>
-          <label className="text-xs font-semibold text-slate-500">Categoría</label>
+          <label className="text-xs font-semibold text-slate-500" htmlFor="movement-category-filter">
+            Categoría
+          </label>
           <select
+            id="movement-category-filter"
             value={categoryFilter}
             onChange={(event) => setCategoryFilter(event.target.value)}
             className="mt-1 h-10 rounded-xl border border-slate-200 px-3 text-sm"

--- a/latin-ecom/src/pages/OrdersPage.tsx
+++ b/latin-ecom/src/pages/OrdersPage.tsx
@@ -63,8 +63,11 @@ const OrdersPage = () => {
       >
         <div className="flex flex-wrap gap-4">
           <div>
-            <label className="text-xs font-semibold text-slate-500">Estado</label>
+            <label className="text-xs font-semibold text-slate-500" htmlFor="order-status-filter">
+              Estado
+            </label>
             <select
+              id="order-status-filter"
               value={selectedStatus}
               onChange={(event) => setSelectedStatus(event.target.value)}
               className="mt-1 h-10 rounded-xl border border-slate-200 px-3 text-sm"
@@ -75,8 +78,11 @@ const OrdersPage = () => {
             </select>
           </div>
           <div>
-            <label className="text-xs font-semibold text-slate-500">Método de pago</label>
+            <label className="text-xs font-semibold text-slate-500" htmlFor="order-payment-filter">
+              Método de pago
+            </label>
             <select
+              id="order-payment-filter"
               value={paymentMethod}
               onChange={(event) => setPaymentMethod(event.target.value)}
               className="mt-1 h-10 rounded-xl border border-slate-200 px-3 text-sm"

--- a/latin-ecom/src/pages/ProductsPage.tsx
+++ b/latin-ecom/src/pages/ProductsPage.tsx
@@ -53,10 +53,13 @@ const ProductsPage = () => {
     >
       <div className="grid gap-4 md:grid-cols-3">
         <div className="md:col-span-2">
-          <label className="text-xs font-semibold text-slate-500">Buscar producto</label>
+          <label className="text-xs font-semibold text-slate-500" htmlFor="product-search">
+            Buscar producto
+          </label>
           <div className="mt-1 flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3">
             <Search size={16} className="text-slate-400" />
             <input
+              id="product-search"
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               className="h-10 flex-1 border-0 bg-transparent text-sm text-secondary focus:outline-none"
@@ -65,8 +68,11 @@ const ProductsPage = () => {
           </div>
         </div>
         <div>
-          <label className="text-xs font-semibold text-slate-500">Categoría</label>
+          <label className="text-xs font-semibold text-slate-500" htmlFor="category-filter">
+            Categoría
+          </label>
           <select
+            id="category-filter"
             value={category}
             onChange={(event) => setCategory(event.target.value)}
             className="mt-1 h-10 w-full rounded-xl border border-slate-200 px-3 text-sm"
@@ -77,8 +83,11 @@ const ProductsPage = () => {
           </select>
         </div>
         <div>
-          <label className="text-xs font-semibold text-slate-500">Proveedor</label>
+          <label className="text-xs font-semibold text-slate-500" htmlFor="provider-filter">
+            Proveedor
+          </label>
           <select
+            id="provider-filter"
             value={provider}
             onChange={(event) => setProvider(event.target.value)}
             className="mt-1 h-10 w-full rounded-xl border border-slate-200 px-3 text-sm"

--- a/latin-ecom/src/test/fixtures/index.ts
+++ b/latin-ecom/src/test/fixtures/index.ts
@@ -1,0 +1,197 @@
+import type {
+  BillingBreakdownItem,
+  Connection,
+  DashboardResponse,
+  Movement,
+  Order,
+  Product,
+  WalletRequest
+} from '../../utils/types';
+
+export const dashboardResponse: DashboardResponse = {
+  orders: [
+    {
+      id: 'ORD-1001',
+      store: 'SofiFit Store',
+      product: 'Kit de bandas elásticas',
+      customer: 'María Paredes',
+      createdAt: '2024-07-28T15:00:00.000Z',
+      status: 'Entregado',
+      paymentMethod: 'TC',
+      cost: 34,
+      shippingCost: 6,
+      salePrice: 55,
+      trackingCode: 'TRK-5551'
+    },
+    {
+      id: 'ORD-1002',
+      store: 'SofiFit Store',
+      product: 'Botella inteligente 1L',
+      customer: 'Andrea Díaz',
+      createdAt: '2024-07-27T13:30:00.000Z',
+      status: 'Pendiente',
+      paymentMethod: 'COD',
+      cost: 21,
+      shippingCost: 5,
+      salePrice: 39,
+      trackingCode: undefined
+    },
+    {
+      id: 'ORD-1003',
+      store: 'SofiFit Store',
+      product: 'Proteína vegana cacao',
+      customer: 'Lucía Chávez',
+      createdAt: '2024-07-20T09:45:00.000Z',
+      status: 'En revisión',
+      paymentMethod: 'TC',
+      cost: 42,
+      shippingCost: 8,
+      salePrice: 72,
+      trackingCode: 'TRK-5582'
+    }
+  ],
+  movements: [
+    {
+      id: 'MOV-2001',
+      type: 'Ingreso',
+      category: 'Confirmación pedido',
+      description: 'Venta Kit de bandas elásticas',
+      amount: 75,
+      date: '2024-07-28T18:30:00.000Z'
+    },
+    {
+      id: 'MOV-2002',
+      type: 'Egreso',
+      category: 'Envío',
+      description: 'Logística pedido ORD-1001',
+      amount: -12,
+      date: '2024-07-28T19:00:00.000Z'
+    },
+    {
+      id: 'MOV-2003',
+      type: 'Ingreso',
+      category: 'Acreditación',
+      description: 'Recarga manual',
+      amount: 1500,
+      date: '2024-07-18T11:15:00.000Z'
+    }
+  ],
+  products: [
+    {
+      id: 'PROD-10',
+      name: 'Kit de bandas elásticas',
+      category: 'Fitness',
+      provider: 'MovePro',
+      cost: 34,
+      suggestedPrice: 59,
+      stock: 120,
+      shippingTime: '48 horas',
+      updatedAt: '2024-07-26T10:00:00.000Z',
+      rating: 4.8
+    },
+    {
+      id: 'PROD-11',
+      name: 'Botella inteligente 1L',
+      category: 'Accesorios',
+      provider: 'HydrateX',
+      cost: 21,
+      suggestedPrice: 39,
+      stock: 85,
+      shippingTime: '72 horas',
+      updatedAt: '2024-07-24T10:00:00.000Z',
+      rating: 4.6
+    },
+    {
+      id: 'PROD-12',
+      name: 'Proteína vegana cacao',
+      category: 'Nutrición',
+      provider: 'GreenFuel',
+      cost: 42,
+      suggestedPrice: 75,
+      stock: 40,
+      shippingTime: '5 días',
+      updatedAt: '2024-07-22T10:00:00.000Z',
+      rating: 4.9
+    }
+  ],
+  orderStatusSummary: [
+    { status: 'Pendiente', value: 4 },
+    { status: 'En revisión', value: 2 },
+    { status: 'Entregado', value: 12 },
+    { status: 'Cancelado', value: 1 }
+  ],
+  topProducts: [
+    { product: 'Kit de bandas elásticas', units: 38, revenue: 2210 },
+    { product: 'Proteína vegana cacao', units: 25, revenue: 1875 },
+    { product: 'Botella inteligente 1L', units: 49, revenue: 1911 }
+  ],
+  billingBreakdown: [
+    { name: 'Costos de producto', value: 3250 },
+    { name: 'Comisiones', value: 950 },
+    { name: 'Logística', value: 780 }
+  ]
+};
+
+export const products: Product[] = dashboardResponse.products;
+
+export const orders: Order[] = dashboardResponse.orders;
+
+export const movements: Movement[] = dashboardResponse.movements;
+
+export const walletRequests: WalletRequest[] = [
+  {
+    id: 'REQ-3001',
+    type: 'Ingreso',
+    status: 'Pendiente',
+    amount: 450,
+    createdAt: '2024-07-25T12:00:00.000Z',
+    reference: 'Recarga USDT Julio'
+  },
+  {
+    id: 'REQ-3002',
+    type: 'Retiro',
+    status: 'Aprobada',
+    amount: 320,
+    createdAt: '2024-07-20T09:30:00.000Z',
+    processedAt: '2024-07-20T14:45:00.000Z',
+    reference: 'Pago proveedor semana 29'
+  },
+  {
+    id: 'REQ-3003',
+    type: 'Retiro',
+    status: 'Rechazada',
+    amount: 210,
+    createdAt: '2024-07-18T16:15:00.000Z',
+    processedAt: '2024-07-18T18:30:00.000Z',
+    reference: 'Reintegro tarjetas COD'
+  }
+];
+
+export const connections: Connection[] = [
+  {
+    id: 'CON-5001',
+    storeName: 'SofiFit Shopify',
+    platform: 'Shopify',
+    status: 'Activa',
+    connectedAt: '2024-05-10T10:00:00.000Z',
+    lastSync: '2024-07-30T22:10:00.000Z'
+  },
+  {
+    id: 'CON-5002',
+    storeName: 'Wellness Peru',
+    platform: 'Shopify',
+    status: 'Sincronizando',
+    connectedAt: '2024-06-01T11:30:00.000Z',
+    lastSync: '2024-07-30T21:50:00.000Z'
+  },
+  {
+    id: 'CON-5003',
+    storeName: 'Healthy Life Co',
+    platform: 'Shopify',
+    status: 'Error',
+    connectedAt: '2024-04-22T09:00:00.000Z',
+    lastSync: '2024-07-29T18:40:00.000Z'
+  }
+];
+
+export const billingBreakdown: BillingBreakdownItem[] = dashboardResponse.billingBreakdown;

--- a/latin-ecom/src/test/setup.ts
+++ b/latin-ecom/src/test/setup.ts
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeAll, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+beforeAll(() => {
+  vi.setSystemTime(new Date('2024-08-01T12:00:00.000Z'));
+
+  class ResizeObserverMock {
+    observe() {
+      return void 0;
+    }
+    unobserve() {
+      return void 0;
+    }
+    disconnect() {
+      return void 0;
+    }
+  }
+
+  // @ts-expect-error - jsdom no define ResizeObserver por defecto
+  global.ResizeObserver = ResizeObserverMock;
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/latin-ecom/tests/e2e/app.spec.ts
+++ b/latin-ecom/tests/e2e/app.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from '@playwright/test';
+import {
+  dashboardResponse,
+  products,
+  orders,
+  movements,
+  walletRequests,
+  connections,
+  billingBreakdown
+} from '../../src/test/fixtures';
+
+test.beforeEach(async ({ page }) => {
+  const consoleErrors: string[] = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  page.on('pageerror', (error) => {
+    consoleErrors.push(error.message);
+  });
+
+  await page.route('**/api/dashboard**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: dashboardResponse })
+    });
+  });
+
+  await page.route('**/api/products**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: products })
+    });
+  });
+
+  await page.route('**/api/orders**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: orders })
+    });
+  });
+
+  await page.route('**/api/movements**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: movements })
+    });
+  });
+
+  await page.route('**/api/wallet-requests**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: walletRequests })
+    });
+  });
+
+  await page.route('**/api/connections**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: connections })
+    });
+  });
+
+  await page.route('**/api/billing**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: billingBreakdown })
+    });
+  });
+
+  await page.goto('/');
+  await expect(page.getByText('Pedidos entregados')).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});
+
+test('recorrido principal verifica navegación y botones críticos', async ({ page }) => {
+  const sections = [
+    {
+      label: 'Dashboard',
+      assertion: async () => {
+        await expect(page.getByText('Pedidos con incidencias')).toBeVisible();
+      }
+    },
+    {
+      label: 'Productos',
+      assertion: async () => {
+        await page.getByRole('link', { name: 'Productos' }).click();
+        await expect(page.getByText('Catálogo de productos')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Exportar CSV' })).toBeEnabled();
+        await expect(page.getByRole('button', { name: 'Agregar a mi tienda' }).first()).toBeEnabled();
+      }
+    },
+    {
+      label: 'Pedidos',
+      assertion: async () => {
+        await page.getByRole('link', { name: 'Pedidos' }).click();
+        await expect(page.getByText('Gestión de pedidos')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Exportar reporte' })).toBeEnabled();
+        await page.getByText('ORD-1002').click();
+        await expect(page.getByText('Detalle del pedido')).toBeVisible();
+      }
+    },
+    {
+      label: 'Conexiones',
+      assertion: async () => {
+        await page.getByRole('link', { name: 'Conexiones' }).click();
+        await expect(page.getByText('Tiendas conectadas')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Conectar nueva tienda' })).toBeEnabled();
+        await page.getByRole('button', { name: 'Sincronizar ahora' }).first().click();
+      }
+    },
+    {
+      label: 'Movimientos',
+      assertion: async () => {
+        await page.getByRole('link', { name: 'Movimientos' }).click();
+        await expect(page.getByText('Movimientos de billetera')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Exportar CSV' })).toBeEnabled();
+      }
+    },
+    {
+      label: 'Solicitudes',
+      assertion: async () => {
+        await page.getByRole('link', { name: 'Solicitudes' }).click();
+        await expect(page.getByText('Solicitudes financieras')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Ingresar dinero' })).toBeEnabled();
+        await expect(page.getByRole('button', { name: 'Retirar dinero' })).toBeEnabled();
+      }
+    },
+    {
+      label: 'Mi cuenta',
+      assertion: async () => {
+        await page.getByRole('link', { name: 'Mi cuenta' }).click();
+        await expect(page.getByText('Configuración de facturación')).toBeVisible();
+        const toggles = page.getByRole('checkbox');
+        await expect(toggles.first()).toBeChecked();
+      }
+    },
+    {
+      label: 'Mi perfil',
+      assertion: async () => {
+        await page.getByRole('link', { name: 'Mi perfil' }).click();
+        await expect(page.getByText('Información personal')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Guardar cambios' })).toBeEnabled();
+      }
+    }
+  ];
+
+  for (const section of sections) {
+    await section.assertion();
+  }
+});
+
+test('captura de pantalla del dashboard sin errores de consola', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('Dashboard')).toBeVisible({ timeout: 5000 });
+  const screenshot = await page.screenshot({ fullPage: true });
+  await test.info().attach('dashboard', { body: screenshot, contentType: 'image/png' });
+});

--- a/latin-ecom/tsconfig.json
+++ b/latin-ecom/tsconfig.json
@@ -11,8 +11,8 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "vitest/globals"]
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/latin-ecom/vite.config.ts
+++ b/latin-ecom/vite.config.ts
@@ -6,5 +6,17 @@ export default defineConfig({
   server: {
     port: 5173,
     host: true
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts',
+    css: true,
+    exclude: ['tests/**/*', 'node_modules/**/*'],
+    coverage: {
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/main.tsx', 'src/test/**']
+    }
   }
 });


### PR DESCRIPTION
## Summary
- add vitest-based component and page tests with shared fixtures and setup helpers
- improve accessibility on filter controls and layout toggle to support test automation
- configure Playwright with API mocks to validate navigation, console errors, and screenshots

## Testing
- npm run test:unit
- npm run test:e2e *(fails: browsers not downloaded in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e437e61cf883288b859ed7823d756d