### PR TITLE
feat: add login flow and admin product management

### DIFF
--- a/latin-ecom-backend/src/data.ts
+++ b/latin-ecom-backend/src/data.ts
@@ -9,6 +9,7 @@ import {
   OrderStatusSummaryItem,
   Product,
   TopProductSummary,
+  User,
   WalletRequest
 } from './types.js';
 
@@ -229,6 +230,23 @@ const initialConnections: Connection[] = [
     status: 'Error',
     connectedAt: subDays(today, 30).toISOString(),
     lastSync: subDays(today, 3).toISOString()
+  }
+];
+
+export const users: User[] = [
+  {
+    id: 'USR-100',
+    name: 'Sofía Martínez',
+    email: 'sofia@latinecom.com',
+    password: 'dropship123',
+    role: 'dropshipper'
+  },
+  {
+    id: 'USR-101',
+    name: 'Ana González',
+    email: 'ana@latinecom.com',
+    password: 'admin123',
+    role: 'admin'
   }
 ];
 

--- a/latin-ecom-backend/src/types.ts
+++ b/latin-ecom-backend/src/types.ts
@@ -65,6 +65,16 @@ export interface Connection {
   lastSync: string;
 }
 
+export type UserRole = 'admin' | 'dropshipper';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+}
+
 export interface OrderStatusSummaryItem {
   status: OrderStatus;
   value: number;

--- a/latin-ecom/src/App.tsx
+++ b/latin-ecom/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import DashboardLayout from './layouts/DashboardLayout';
 import HomePage from './pages/HomePage';
 import ProductsPage from './pages/ProductsPage';
@@ -8,11 +8,24 @@ import MovementsPage from './pages/MovementsPage';
 import RequestsPage from './pages/RequestsPage';
 import AccountPage from './pages/AccountPage';
 import ProfilePage from './pages/ProfilePage';
+import LoginPage from './pages/LoginPage';
+import { useAuth } from './contexts/AuthContext';
+import ProtectedRoute from './components/ProtectedRoute';
+import FullScreenLoader from './components/FullScreenLoader';
 
 const App = () => {
+  const { user, status } = useAuth();
+  const isChecking = status === 'loading';
+
   return (
-    <DashboardLayout>
-      <Routes>
+    <Routes>
+      <Route
+        path="/login"
+        element={
+          isChecking ? <FullScreenLoader message="Validando sesión..." /> : user ? <Navigate to="/" replace /> : <LoginPage />
+        }
+      />
+      <Route element={<ProtectedRoute />}> 
         <Route path="/" element={<HomePage />} />
         <Route path="/productos" element={<ProductsPage />} />
         <Route path="/pedidos" element={<OrdersPage />} />
@@ -21,9 +34,9 @@ const App = () => {
         <Route path="/wallet/solicitudes" element={<RequestsPage />} />
         <Route path="/mi-cuenta" element={<AccountPage />} />
         <Route path="/mi-perfil" element={<ProfilePage />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
-    </DashboardLayout>
+      </Route>
+      <Route path="*" element={<Navigate to={user ? '/' : '/login'} replace />} />
+    </Routes>
   );
 };
 

--- a/latin-ecom/src/api/client.ts
+++ b/latin-ecom/src/api/client.ts
@@ -4,6 +4,8 @@ type RequestOptions = RequestInit & { query?: Record<string, string | number | b
 
 const baseUrl = (import.meta.env.VITE_API_URL ?? 'http://localhost:4000').replace(/\/$/, '');
 
+let authToken: string | null = null;
+
 const buildUrl = (path: string, query?: RequestOptions['query']) => {
   const url = new URL(`${baseUrl}${path}`);
   if (query) {
@@ -21,6 +23,7 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     ...rest,
     headers: {
       'Content-Type': 'application/json',
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
       ...headers
     }
   });
@@ -42,6 +45,10 @@ export const apiClient = {
   get: request,
   post: <T>(path: string, body: unknown) => request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
   patch: <T>(path: string, body: unknown) => request<T>(path, { method: 'PATCH', body: JSON.stringify(body) })
+};
+
+export const setAuthToken = (token: string | null) => {
+  authToken = token;
 };
 
 export type { RequestOptions };

--- a/latin-ecom/src/components/FullScreenLoader.tsx
+++ b/latin-ecom/src/components/FullScreenLoader.tsx
@@ -1,0 +1,12 @@
+const FullScreenLoader = ({ message = 'Cargando...' }: { message?: string }) => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-100">
+      <div className="flex flex-col items-center gap-3 rounded-2xl bg-white px-8 py-6 shadow-lg">
+        <div className="h-10 w-10 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        <p className="text-sm font-medium text-slate-600">{message}</p>
+      </div>
+    </div>
+  );
+};
+
+export default FullScreenLoader;

--- a/latin-ecom/src/components/ProductFormModal.tsx
+++ b/latin-ecom/src/components/ProductFormModal.tsx
@@ -1,0 +1,223 @@
+import { ChangeEvent, FormEvent, useEffect, useState } from 'react';
+import { Product } from '../utils/types';
+
+export type ProductFormValues = {
+  name: string;
+  category: string;
+  provider: string;
+  cost: number;
+  suggestedPrice: number;
+  stock: number;
+  shippingTime: string;
+  rating: number;
+};
+
+type ProductFormModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (values: ProductFormValues) => Promise<void> | void;
+  initialValues?: Product | null;
+  isSubmitting: boolean;
+  error?: string | null;
+};
+
+const emptyFormState = {
+  name: '',
+  category: '',
+  provider: '',
+  cost: '0',
+  suggestedPrice: '0',
+  stock: '0',
+  shippingTime: '',
+  rating: '4.5'
+};
+
+type FormState = typeof emptyFormState;
+
+const ProductFormModal = ({ isOpen, onClose, onSubmit, initialValues, isSubmitting, error }: ProductFormModalProps) => {
+  const [formState, setFormState] = useState<FormState>(emptyFormState);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (initialValues) {
+      setFormState({
+        name: initialValues.name,
+        category: initialValues.category,
+        provider: initialValues.provider,
+        cost: initialValues.cost.toString(),
+        suggestedPrice: initialValues.suggestedPrice.toString(),
+        stock: initialValues.stock.toString(),
+        shippingTime: initialValues.shippingTime,
+        rating: initialValues.rating.toString()
+      });
+    } else {
+      setFormState(emptyFormState);
+    }
+  }, [initialValues, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleChange = (field: keyof FormState) => (event: ChangeEvent<HTMLInputElement>) => {
+    setFormState((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const values: ProductFormValues = {
+      name: formState.name.trim(),
+      category: formState.category.trim(),
+      provider: formState.provider.trim(),
+      cost: Number(formState.cost),
+      suggestedPrice: Number(formState.suggestedPrice),
+      stock: Number(formState.stock),
+      shippingTime: formState.shippingTime.trim(),
+      rating: Number(formState.rating)
+    };
+    await onSubmit(values);
+  };
+
+  const title = initialValues ? 'Actualizar ficha de producto' : 'Cargar nuevo producto';
+  const subtitle = initialValues
+    ? 'Actualiza los datos comerciales y logísticos del producto seleccionado.'
+    : 'Completa la información clave para disponibilizar un nuevo producto en el catálogo.';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 py-6">
+      <div className="w-full max-w-2xl rounded-3xl bg-white p-6 shadow-2xl">
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-secondary">{title}</h2>
+            <p className="mt-1 text-sm text-slate-500">{subtitle}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-500 hover:border-primary hover:text-primary"
+          >
+            Cerrar
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-6 grid gap-4 sm:grid-cols-2">
+          <div className="sm:col-span-2">
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Nombre</label>
+            <input
+              required
+              value={formState.name}
+              onChange={handleChange('name')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="Nombre comercial"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Categoría</label>
+            <input
+              required
+              value={formState.category}
+              onChange={handleChange('category')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="Ej. Belleza"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Proveedor</label>
+            <input
+              required
+              value={formState.provider}
+              onChange={handleChange('provider')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="Nombre proveedor"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Costo dropshipper</label>
+            <input
+              required
+              type="number"
+              min="0"
+              step="0.01"
+              value={formState.cost}
+              onChange={handleChange('cost')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Precio sugerido</label>
+            <input
+              required
+              type="number"
+              min="0"
+              step="0.01"
+              value={formState.suggestedPrice}
+              onChange={handleChange('suggestedPrice')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Stock</label>
+            <input
+              required
+              type="number"
+              min="0"
+              step="1"
+              value={formState.stock}
+              onChange={handleChange('stock')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Tiempo de envío</label>
+            <input
+              required
+              value={formState.shippingTime}
+              onChange={handleChange('shippingTime')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="Ej. 48h"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">Rating</label>
+            <input
+              required
+              type="number"
+              min="0"
+              max="5"
+              step="0.1"
+              value={formState.rating}
+              onChange={handleChange('rating')}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+            />
+          </div>
+
+          {error ? (
+            <p className="sm:col-span-2 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>
+          ) : null}
+
+          <div className="sm:col-span-2 flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="w-full rounded-xl border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-600 transition-colors hover:border-primary hover:text-primary sm:w-auto"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+            >
+              {isSubmitting ? 'Guardando...' : initialValues ? 'Guardar cambios' : 'Crear producto'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ProductFormModal;

--- a/latin-ecom/src/components/ProtectedRoute.tsx
+++ b/latin-ecom/src/components/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate } from 'react-router-dom';
+import DashboardLayout from '../layouts/DashboardLayout';
+import { useAuth } from '../contexts/AuthContext';
+import FullScreenLoader from './FullScreenLoader';
+
+const ProtectedRoute = () => {
+  const { user, status } = useAuth();
+
+  if (status === 'loading') {
+    return <FullScreenLoader message="Validando sesión..." />;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <DashboardLayout />;
+};
+
+export default ProtectedRoute;

--- a/latin-ecom/src/contexts/AuthContext.tsx
+++ b/latin-ecom/src/contexts/AuthContext.tsx
@@ -1,0 +1,92 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+import { apiClient, setAuthToken } from '../api/client';
+import { ApiItemResponse, AuthSuccess, User } from '../utils/types';
+
+const STORAGE_KEY = 'latin-ecom/auth-token';
+
+type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+type AuthContextValue = {
+  user: User | null;
+  status: AuthStatus;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [status, setStatus] = useState<AuthStatus>('loading');
+
+  useEffect(() => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+    if (!token) {
+      setStatus('unauthenticated');
+      return;
+    }
+
+    setAuthToken(token);
+    apiClient
+      .get<ApiItemResponse<User>>('/api/auth/me')
+      .then((response) => {
+        setUser(response.data);
+        setStatus('authenticated');
+      })
+      .catch(() => {
+        setAuthToken(null);
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem(STORAGE_KEY);
+        }
+        setStatus('unauthenticated');
+      });
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    setStatus('loading');
+    try {
+      const response = await apiClient.post<ApiItemResponse<AuthSuccess>>('/api/auth/login', {
+        email,
+        password
+      });
+      setAuthToken(response.data.token);
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(STORAGE_KEY, response.data.token);
+      }
+      setUser(response.data.user);
+      setStatus('authenticated');
+    } catch (error) {
+      setStatus(user ? 'authenticated' : 'unauthenticated');
+      throw error;
+    }
+  };
+
+  const logout = () => {
+    setUser(null);
+    setAuthToken(null);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+    setStatus('unauthenticated');
+  };
+
+  const value = useMemo(
+    () => ({
+      user,
+      status,
+      login,
+      logout
+    }),
+    [user, status]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/latin-ecom/src/layouts/DashboardLayout.tsx
+++ b/latin-ecom/src/layouts/DashboardLayout.tsx
@@ -1,8 +1,8 @@
-import { ReactNode } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { Menu, Wallet, Home, PackageSearch, ShoppingCart, Link2, User, Settings } from 'lucide-react';
 import { useState } from 'react';
 import clsx from 'clsx';
+import { useAuth } from '../contexts/AuthContext';
 
 const navItems = [
   { to: '/', label: 'Dashboard', icon: Home },
@@ -15,9 +15,26 @@ const navItems = [
   { to: '/mi-perfil', label: 'Mi perfil', icon: User }
 ];
 
-const DashboardLayout = ({ children }: { children: ReactNode }) => {
+const roleLabels: Record<string, string> = {
+  admin: 'Administrador',
+  dropshipper: 'Dropshipper'
+};
+
+const getInitials = (name: string) =>
+  name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('');
+
+const DashboardLayout = () => {
   const [isOpen, setIsOpen] = useState(true);
   const location = useLocation();
+  const { user, logout } = useAuth();
+
+  const initials = user ? getInitials(user.name) : 'US';
+  const roleLabel = user ? roleLabels[user.role] ?? user.role : '';
 
   return (
     <div className="flex min-h-screen bg-slate-100">
@@ -65,8 +82,8 @@ const DashboardLayout = ({ children }: { children: ReactNode }) => {
                 <Menu size={18} />
               </button>
               <div>
-                <p className="text-sm text-slate-500">Bienvenido de nuevo</p>
-                <h1 className="text-xl font-semibold text-secondary">Sofía Martínez</h1>
+                <p className="text-xs font-semibold uppercase tracking-wide text-primary">{roleLabel}</p>
+                <h1 className="text-xl font-semibold text-secondary">{user?.name ?? 'Usuario'}</h1>
               </div>
             </div>
             <div className="flex items-center gap-4">
@@ -75,15 +92,33 @@ const DashboardLayout = ({ children }: { children: ReactNode }) => {
                 <p className="text-lg font-semibold text-primary">USDT 3,450.00</p>
               </div>
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary font-semibold">
-                SM
+                {initials}
               </div>
+              <button
+                type="button"
+                onClick={logout}
+                className="hidden rounded-xl border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition-colors hover:border-primary hover:text-primary md:inline-flex"
+              >
+                Cerrar sesión
+              </button>
             </div>
           </div>
           <div className="px-6 pb-4 text-sm text-slate-400">
             {navItems.find((item) => item.to === location.pathname)?.label ?? 'Dashboard general'}
           </div>
         </header>
-        <main className="flex-1 px-4 py-6 lg:px-8">{children}</main>
+        <main className="flex-1 px-4 py-6 lg:px-8">
+          <Outlet />
+        </main>
+        <div className="block px-6 pb-6 md:hidden">
+          <button
+            type="button"
+            onClick={logout}
+            className="w-full rounded-xl border border-slate-200 px-4 py-3 text-sm font-semibold text-slate-600 transition-colors hover:border-primary hover:text-primary"
+          >
+            Cerrar sesión
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/latin-ecom/src/main.tsx
+++ b/latin-ecom/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './index.css';
+import { AuthProvider } from './contexts/AuthContext';
 
 const client = new QueryClient();
 
@@ -11,7 +12,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <QueryClientProvider client={client}>
       <BrowserRouter>
-        <App />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>

--- a/latin-ecom/src/pages/LoginPage.tsx
+++ b/latin-ecom/src/pages/LoginPage.tsx
@@ -1,0 +1,124 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { ApiError } from '../utils/errors';
+
+const demoAccounts = [
+  { role: 'Dropshipper', email: 'sofia@latinecom.com', password: 'dropship123' },
+  { role: 'Administrador', email: 'ana@latinecom.com', password: 'admin123' }
+];
+
+const LoginPage = () => {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await login(email, password);
+      navigate('/', { replace: true });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setError('Credenciales inválidas. Verifica tu correo y contraseña.');
+      } else {
+        setError('No fue posible iniciar sesión. Intenta nuevamente más tarde.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handlePrefill = (accountEmail: string, accountPassword: string) => {
+    setEmail(accountEmail);
+    setPassword(accountPassword);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-100 px-4 py-8">
+      <div className="grid w-full max-w-5xl gap-12 rounded-3xl bg-white p-10 shadow-xl md:grid-cols-[1.1fr_0.9fr]">
+        <section>
+          <span className="text-sm font-semibold uppercase tracking-wide text-primary">LatinEcom</span>
+          <h1 className="mt-3 text-3xl font-semibold text-secondary md:text-4xl">Accede a tu panel</h1>
+          <p className="mt-2 text-sm text-slate-500">
+            Gestiona pedidos, catálogo y finanzas desde un único lugar. Inicia sesión con tu cuenta de dropshipper o
+            administrador.
+          </p>
+
+          <div className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-6">
+            <h2 className="text-base font-semibold text-secondary">Cuentas de demostración</h2>
+            <p className="mt-1 text-sm text-slate-500">Selecciona una cuenta para autocompletar las credenciales.</p>
+            <div className="mt-4 grid gap-3">
+              {demoAccounts.map((account) => (
+                <button
+                  key={account.email}
+                  type="button"
+                  onClick={() => handlePrefill(account.email, account.password)}
+                  className="flex items-center justify-between rounded-xl border border-slate-200 px-4 py-3 text-left text-sm font-medium text-secondary transition-colors hover:border-primary hover:text-primary"
+                >
+                  <span>{account.role}</span>
+                  <span className="text-xs text-slate-500">{account.email}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="flex flex-col justify-center">
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label htmlFor="email" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Correo electrónico
+              </label>
+              <input
+                id="email"
+                type="email"
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm text-secondary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                placeholder="tu@latinecom.com"
+                autoComplete="email"
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Contraseña
+              </label>
+              <input
+                id="password"
+                type="password"
+                required
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm text-secondary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+                placeholder="••••••••"
+                autoComplete="current-password"
+              />
+            </div>
+
+            {error ? <p className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p> : null}
+
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? 'Ingresando...' : 'Iniciar sesión'}
+            </button>
+          </form>
+          <p className="mt-6 text-xs text-slate-400">
+            ¿Necesitas una cuenta? Contacta al administrador de LatinEcom para habilitar tu acceso.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/latin-ecom/src/pages/ProductsPage.tsx
+++ b/latin-ecom/src/pages/ProductsPage.tsx
@@ -1,10 +1,15 @@
 import { useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import SectionCard from '../components/SectionCard';
-import { Star, Filter, Search } from 'lucide-react';
+import { Star, Filter, Search, Plus, Pencil } from 'lucide-react';
 import { useProducts } from '../api/hooks';
 import LoadingState from '../components/LoadingState';
 import ErrorState from '../components/ErrorState';
-import { Product } from '../utils/types';
+import { ApiItemResponse, Product } from '../utils/types';
+import { useAuth } from '../contexts/AuthContext';
+import ProductFormModal, { ProductFormValues } from '../components/ProductFormModal';
+import { apiClient } from '../api/client';
+import { ApiError } from '../utils/errors';
 
 const uniqueValues = (items: string[]) => Array.from(new Set(items)).sort();
 
@@ -14,6 +19,25 @@ const ProductsPage = () => {
   const [search, setSearch] = useState('');
   const [category, setCategory] = useState('Todas');
   const [provider, setProvider] = useState('Todos');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
+
+  const createProductMutation = useMutation({
+    mutationFn: (payload: ProductFormValues) =>
+      apiClient.post<ApiItemResponse<Product>>('/api/products', payload)
+  });
+
+  const updateProductMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ProductFormValues }) =>
+      apiClient.patch<ApiItemResponse<Product>>(`/api/products/${id}`, data)
+  });
+
+  const isSaving = createProductMutation.isPending || updateProductMutation.isPending;
+
   const categories = useMemo(
     () => ['Todas', ...uniqueValues(products.map((product: Product) => product.category))],
     [products]
@@ -32,6 +56,49 @@ const ProductsPage = () => {
     });
   }, [category, products, provider, search]);
 
+  const handleOpenCreate = () => {
+    setSelectedProduct(null);
+    setFormError(null);
+    setIsModalOpen(true);
+  };
+
+  const handleOpenEdit = (product: Product) => {
+    setSelectedProduct(product);
+    setFormError(null);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedProduct(null);
+    setFormError(null);
+    createProductMutation.reset();
+    updateProductMutation.reset();
+  };
+
+  const handleSubmitProduct = async (values: ProductFormValues) => {
+    setFormError(null);
+    try {
+      if (selectedProduct) {
+        await updateProductMutation.mutateAsync({ id: selectedProduct.id, data: values });
+      } else {
+        await createProductMutation.mutateAsync(values);
+      }
+      await queryClient.invalidateQueries({ queryKey: ['products'] });
+      handleCloseModal();
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (typeof (error.details as { error?: string })?.error === 'string') {
+          setFormError((error.details as { error?: string }).error ?? error.message);
+        } else {
+          setFormError(error.message);
+        }
+      } else {
+        setFormError('No fue posible guardar el producto. Intenta nuevamente.');
+      }
+    }
+  };
+
   if (isLoading) {
     return <LoadingState message="Cargando catálogo de productos..." />;
   }
@@ -45,10 +112,22 @@ const ProductsPage = () => {
       title="Catálogo de productos"
       subtitle="Explora el inventario disponible para dropshipping"
       action={
-        <button className="inline-flex items-center gap-2 rounded-xl border border-primary px-4 py-2 text-sm font-semibold text-primary">
-          <Filter size={16} />
-          Exportar CSV
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button className="inline-flex items-center gap-2 rounded-xl border border-primary px-4 py-2 text-sm font-semibold text-primary">
+            <Filter size={16} />
+            Exportar CSV
+          </button>
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={handleOpenCreate}
+              className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary/90"
+            >
+              <Plus size={16} />
+              Cargar producto
+            </button>
+          )}
+        </div>
       }
     >
       <div className="grid gap-4 md:grid-cols-3">
@@ -124,13 +203,38 @@ const ProductsPage = () => {
                 <Star size={16} fill="currentColor" />
                 <span>{product.rating.toFixed(1)}</span>
               </div>
-              <button className="rounded-xl bg-primary px-4 py-2 text-xs font-semibold text-white shadow-sm">
-                Agregar a mi tienda
-              </button>
+              {isAdmin ? (
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleOpenEdit(product)}
+                    className="inline-flex items-center gap-2 rounded-xl border border-primary px-3 py-2 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                  >
+                    <Pencil size={14} />
+                    Editar ficha
+                  </button>
+                  <button className="rounded-xl bg-primary px-4 py-2 text-xs font-semibold text-white shadow-sm">
+                    Agregar a mi tienda
+                  </button>
+                </div>
+              ) : (
+                <button className="rounded-xl bg-primary px-4 py-2 text-xs font-semibold text-white shadow-sm">
+                  Agregar a mi tienda
+                </button>
+              )}
             </div>
           </article>
         ))}
       </div>
+
+      <ProductFormModal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        onSubmit={handleSubmitProduct}
+        initialValues={selectedProduct}
+        isSubmitting={isSaving}
+        error={formError}
+      />
     </SectionCard>
   );
 };

--- a/latin-ecom/src/utils/types.ts
+++ b/latin-ecom/src/utils/types.ts
@@ -65,6 +65,15 @@ export interface Connection {
   lastSync: string;
 }
 
+export type UserRole = 'admin' | 'dropshipper';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+}
+
 export interface OrderStatusSummaryItem {
   status: OrderStatus;
   value: number;
@@ -96,4 +105,9 @@ export interface ApiListResponse<T> {
 
 export interface ApiItemResponse<T> {
   data: T;
+}
+
+export interface AuthSuccess {
+  token: string;
+  user: User;
 }


### PR DESCRIPTION
## Summary
- seed backend users, add session-based authentication, protect existing routes, and expose admin endpoints to create or update products
- add a React auth provider with login page, protected routing, and dashboard header that reflects the active user and exposes logout controls
- enable admin management from the catalog with a reusable product form modal and mutations to create or edit product entries

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68e4380bba6083288f1ece45a67a614d