### PR TITLE
Add QA report for full project verification

### DIFF
--- a/QA_REPORT.md
+++ b/QA_REPORT.md
@@ -1,0 +1,21 @@
+# QA Execution Report
+
+## Summary
+- Ejecuté el linter del frontend (`npm run lint`).
+- Intenté ejecutar la suite de pruebas del frontend (`npm run test -- --run`), que finalizó con error porque no existen archivos de prueba.
+- Compilé el frontend (`npm run build`).
+- Compilé el backend (`npm run build`).
+
+## Detalles
+### Frontend (`latin-ecom`)
+- `npm run lint`: finalizó correctamente, pero ESLint mostró una advertencia indicando que `@typescript-eslint` no soporta TypeScript 5.6.3 y podría producir comportamientos inesperados.
+- `npm run test -- --run`: Vitest devolvió el código de salida 1 debido a que no encontró archivos de prueba. No se ejecutaron pruebas automatizadas.
+- `npm run build`: la compilación terminó con éxito. Vite avisó que uno de los chunks supera los 500 kB tras la minificación y sugiere evaluar técnicas de code splitting si se desea optimizarlo.
+
+### Backend (`latin-ecom-backend`)
+- `npm run build`: la compilación TypeScript finalizó sin errores.
+
+## Observaciones
+- Considera agregar pruebas automatizadas para el frontend o ejecutar Vitest con la opción `--passWithNoTests` si el comportamiento deseado es que la tarea no falle en ausencia de pruebas.
+- Evalúa la advertencia sobre la versión de TypeScript utilizada por `@typescript-eslint` para prevenir posibles incompatibilidades futuras.
+- El aviso sobre el tamaño del bundle puede mitigarse aplicando división de código (`dynamic import`) o ajustando `build.chunkSizeWarningLimit` si el tamaño es aceptable para la aplicación.


### PR DESCRIPTION
## Summary
- add a QA report detailing the checks performed on the frontend and backend
- document warnings observed during linting, testing, and builds

## Testing
- npm run lint
- npm run test -- --run
- npm run build (frontend)
- npm run build (backend)


------
https://chatgpt.com/codex/tasks/task_e_68e4387a32988328821291a2806bdb2a